### PR TITLE
Make binary search midpoint calculations safe

### DIFF
--- a/dynamic-programming/longest-increasing-subseq.go
+++ b/dynamic-programming/longest-increasing-subseq.go
@@ -1,0 +1,44 @@
+// an implementation of the longest increasing subsequence
+// Runs in O(nlogn)
+
+package longestincreasing
+
+// import "fmt"
+
+func longest_increasing(arr []int) []int {
+	candidates := [][]int{arr[0:1]}
+
+	for i := 1; i < len(arr); i++ {
+		num := arr[i]
+
+		back := candidates[len(candidates)-1]
+		if num > back[len(back)-1] {
+			temp := append(back, num)
+			candidates = append(candidates, temp)
+		} else if num < candidates[0][0] {
+			candidates[0] = []int{num}
+		} else {
+			start := 0
+			end := len(candidates) - 1
+
+			for end > start+1 {
+				mid := start + int((end-start)/2)
+				curr := candidates[mid]
+				if curr[len(curr)-1] < num {
+					start = mid
+				} else {
+					end = mid
+				}
+			}
+
+			temp := append(candidates[end-1], num)
+			candidates[end] = temp
+		}
+	}
+	return candidates[len(candidates)-1]
+}
+
+// func main() {
+// 	t := []int{4, 6, -1, 4, 0, 12, 8}
+// 	fmt.Println(longest_increasing(t))
+// }

--- a/searches/binary_search.go
+++ b/searches/binary_search.go
@@ -7,7 +7,7 @@ func binarySearch(array []int, target int, lowIndex int, highIndex int) int {
 	if highIndex < lowIndex {
 		return -1
 	}
-	mid := int((lowIndex + highIndex) / 2)
+	mid := lowIndex + int((highIndex - lowIndex) / 2)
 	if array[mid] > target {
 		return binarySearch(array, target, lowIndex, mid)
 	} else if array[mid] < target {
@@ -22,7 +22,7 @@ func iterBinarySearch(array []int, target int, lowIndex int, highIndex int) int 
 	endIndex := highIndex
 	var mid int
 	for startIndex < endIndex {
-		mid = int((startIndex + endIndex) / 2)
+		mid = lowIndex + int((highIndex - lowIndex) / 2)
 		if array[mid] > target {
 			endIndex = mid
 		} else if array[mid] < target {


### PR DESCRIPTION
Using mid = (low + high) / 2 is unsafe as overflows can happen during calculation.
In order to safely calculate the midpoint in a binary search, it is best practice to
use low + ((high - low)/2) as it will not overflow. Google wrote a blog post detailing this problem [here](https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html).