### PR TITLE
Avoids Overflow Errors common in Binary search

### DIFF
--- a/searches/binary_search.go
+++ b/searches/binary_search.go
@@ -7,7 +7,7 @@ func binarySearch(array []int, target int, lowIndex int, highIndex int) int {
 	if highIndex < lowIndex {
 		return -1
 	}
-	mid := int((lowIndex + highIndex) / 2)
+	mid := int(lowIndex + (highIndex-lowIndex)/2)
 	if array[mid] > target {
 		return binarySearch(array, target, lowIndex, mid)
 	} else if array[mid] < target {
@@ -22,7 +22,7 @@ func iterBinarySearch(array []int, target int, lowIndex int, highIndex int) int 
 	endIndex := highIndex
 	var mid int
 	for startIndex < endIndex {
-		mid = int((startIndex + endIndex) / 2)
+		mid = int(startIndex + (endIndex-startIndex))
 		if array[mid] > target {
 			endIndex = mid
 		} else if array[mid] < target {


### PR DESCRIPTION
Adding two large integers then dividing the sum, (a+b)/2 ,might end up creating a sum that can't fit in memory. However this overflow can be avoided by never adding the numbers first instead, adding the difference of the two numbers to the least i.e (a+b)/2 == a+(b-a)/2 == b-(b-a)/2 ... Please comment or ask for further clarification instead of just rejecting the proposal. Thanks