### PR TITLE
data-structures/binary-tree: Move main into tests as per #145

### DIFF
--- a/data-structures/binary-search-tree/binary-search-tree.go
+++ b/data-structures/binary-search-tree/binary-search-tree.go
@@ -1,9 +1,7 @@
 // Binary search tree
 // https://en.wikipedia.org/wiki/Binary_search_tree
 
-package binarySearchTree
-
-// package main
+package binarysearchtree
 
 import "fmt"
 
@@ -92,35 +90,3 @@ func _calculate_depth(n *node, depth int) int {
 func (t *btree) depth() int {
 	return _calculate_depth(t.root, 0)
 }
-
-
-func main() {
-	t := &btree{nil}
-	inorder(t.root)
-	t.root = insert(t.root, 30)
-
-	t.root = insert(t.root, 20)
-	t.root = insert(t.root, 15)
-	t.root = insert(t.root, 10)
-	t.root = insert(t.root, 12)
-	t.root = insert(t.root, 9)
-	t.root = insert(t.root, 11)
-	t.root = insert(t.root, 17)
-	fmt.Print(t.depth(), "\n")
-	inorder(t.root)
-	fmt.Print("\n")
-	t.root = bst_delete(t.root, 10)
-	inorder(t.root)
-	fmt.Print("\n")
-	t.root = bst_delete(t.root, 30)
-	inorder(t.root)
-	fmt.Print("\n")
-	t.root = bst_delete(t.root, 15)
-	inorder(t.root)
-	fmt.Print("\n")
-	t.root = bst_delete(t.root, 20)
-	inorder(t.root)
-	fmt.Print("\n")
-	fmt.Print(t.depth(), "\n")
-}
-

--- a/data-structures/binary-search-tree/binary-search-tree_test.go
+++ b/data-structures/binary-search-tree/binary-search-tree_test.go
@@ -1,0 +1,36 @@
+package binarysearchtree
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestBinarySearchTree(t *testing.T) {
+	bt := &btree{nil}
+	inorder(bt.root)
+	bt.root = insert(bt.root, 30)
+
+	bt.root = insert(bt.root, 20)
+	bt.root = insert(bt.root, 15)
+	bt.root = insert(bt.root, 10)
+	bt.root = insert(bt.root, 12)
+	bt.root = insert(bt.root, 9)
+	bt.root = insert(bt.root, 11)
+	bt.root = insert(bt.root, 17)
+	fmt.Print(bt.depth(), "\n")
+	inorder(bt.root)
+	fmt.Print("\n")
+	bt.root = bst_delete(bt.root, 10)
+	inorder(bt.root)
+	fmt.Print("\n")
+	bt.root = bst_delete(bt.root, 30)
+	inorder(bt.root)
+	fmt.Print("\n")
+	bt.root = bst_delete(bt.root, 15)
+	inorder(bt.root)
+	fmt.Print("\n")
+	bt.root = bst_delete(bt.root, 20)
+	inorder(bt.root)
+	fmt.Print("\n")
+	fmt.Print(bt.depth(), "\n")
+}

--- a/data-structures/binary-tree/binary-tree.go
+++ b/data-structures/binary-tree/binary-tree.go
@@ -2,8 +2,6 @@
 
 package binarytree
 
-// package main
-
 import "fmt"
 
 type node struct {
@@ -84,27 +82,3 @@ func _calculate_depth(n *node, depth int) int {
 func (t *btree) depth() int {
 	return _calculate_depth(t.root, 0)
 }
-
-/*
-func main() {
-	t := btree{nil}
-	t.root = newNode(0)
-	t.root.left = newNode(1)
-	t.root.right = newNode(2)
-	t.root.left.left = newNode(3)
-	t.root.left.right = newNode(4)
-	t.root.right.left = newNode(5)
-	t.root.right.right = newNode(6)
-	t.root.right.right.right = newNode(10)
-
-	inorder(t.root)
-	fmt.Print("\n")
-	preorder(t.root)
-	fmt.Print("\n")
-	postorder(t.root)
-	fmt.Print("\n")
-	levelorder(t.root)
-	fmt.Print("\n")
-	fmt.Print(t.depth(), "\n")
-}
-*/

--- a/data-structures/binary-tree/binary-tree_test.go
+++ b/data-structures/binary-tree/binary-tree_test.go
@@ -1,0 +1,59 @@
+package binarytree
+
+import (
+	"fmt"
+	"testing"
+)
+
+func testTree() btree {
+	bt := btree{nil}
+
+	//        0
+	//   1         2
+	// 3   4     5   6
+	//                 10
+
+	bt.root = newNode(0)
+	bt.root.left = newNode(1)
+	bt.root.right = newNode(2)
+	bt.root.left.left = newNode(3)
+	bt.root.left.right = newNode(4)
+	bt.root.right.left = newNode(5)
+	bt.root.right.right = newNode(6)
+	bt.root.right.right.right = newNode(10)
+
+	return bt
+}
+
+func TestDepth(t *testing.T) {
+	bt := testTree()
+	expectedDepth := 4
+	depth := bt.depth()
+	if depth != expectedDepth {
+		t.Errorf("Incorrect tree depth. Expected %d and got %d\n", expectedDepth, depth)
+	}
+}
+
+func TestTraverseInOrder(t *testing.T) {
+	bt := testTree()
+	inorder(bt.root)
+	fmt.Print("\n")
+}
+
+func TestTraversePreOrder(t *testing.T) {
+	bt := testTree()
+	preorder(bt.root)
+	fmt.Print("\n")
+}
+
+func TestTraversePostOrder(t *testing.T) {
+	bt := testTree()
+	postorder(bt.root)
+	fmt.Print("\n")
+}
+
+func TestTraverseLevelOrder(t *testing.T) {
+	bt := testTree()
+	levelorder(bt.root)
+	fmt.Print("\n")
+}


### PR DESCRIPTION
This moves the ```main``` package and func into a test file so it can be executed without changing the source file and requiring an executable as per #145.

In order to fully utilize the testing mechanisms the results of the operations on the trees need to be asserted like in the depth test. Doing that requires changes to the operations themselves which falls outside the scope of this PR but is easily enabled in future by these test files.

As part of these changes the binary search tree was moved into a separate folder so that the package names no longer clash and lastly the package name was changed from ```binarySearchTree``` to ```binarysearchtree``` to confirm more closely with golang package naming standards.