### PR TITLE
Update iterBinarySearch

### DIFF
--- a/searches/binary_search.go
+++ b/searches/binary_search.go
@@ -19,7 +19,7 @@ func iterBinarySearch(array []int, target int, lowIndex int, highIndex int) int 
 	endIndex := highIndex
 	var mid int
 	for startIndex <= endIndex {
-		mid = int(startIndex + (endIndex-1)/2)
+		mid = int(startIndex + (endIndex)/2)
 		if array[mid] > target {
 			endIndex = mid - 1
 		} else if array[mid] < target {

--- a/searches/binary_search.go
+++ b/searches/binary_search.go
@@ -18,12 +18,12 @@ func iterBinarySearch(array []int, target int, lowIndex int, highIndex int) int 
 	startIndex := lowIndex
 	endIndex := highIndex
 	var mid int
-	for startIndex < endIndex {
-		mid = int(startIndex + (endIndex - startIndex))
+	for startIndex <= endIndex {
+		mid = int(startIndex + (endIndex-1)/2)
 		if array[mid] > target {
-			endIndex = mid
+			endIndex = mid - 1
 		} else if array[mid] < target {
-			startIndex = mid
+			startIndex = mid + 1
 		} else {
 			return mid
 		}

--- a/searches/search_test.go
+++ b/searches/search_test.go
@@ -12,6 +12,10 @@ type searchTest struct {
 var searchTests = []searchTest{
 	//Sanity
 	{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5, 4, "Sanity"},
+	//First
+	{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1, 0, "First"},
+	//Last
+	{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 10, 9, "Last"},
 	//Absent
 	{[]int{1, 4, 5, 6, 7, 10}, 25, -1, "Absent"},
 	//Empty slice
@@ -21,6 +25,15 @@ var searchTests = []searchTest{
 func TestBinarySearch(t *testing.T) {
 	for _, test := range searchTests {
 		actual := binarySearch(test.data, test.key, 0, len(test.data)-1)
+		if actual != test.expected {
+			t.Errorf("test %s failed", test.name)
+		}
+	}
+}
+
+func TestIterBinarySearch(t *testing.T) {
+	for _, test := range searchTests {
+		actual := iterBinarySearch(test.data, test.key, 0, len(test.data)-1)
 		if actual != test.expected {
 			t.Errorf("test %s failed", test.name)
 		}

--- a/searches/search_test.go
+++ b/searches/search_test.go
@@ -26,7 +26,7 @@ func TestBinarySearch(t *testing.T) {
 	for _, test := range searchTests {
 		actual := binarySearch(test.data, test.key, 0, len(test.data)-1)
 		if actual != test.expected {
-			t.Errorf("test %s failed", test.name)
+			t.Errorf("test %s failed: expected '%d', get '%d'", test.name, test.expected, actual)
 		}
 	}
 }
@@ -35,7 +35,7 @@ func TestIterBinarySearch(t *testing.T) {
 	for _, test := range searchTests {
 		actual := iterBinarySearch(test.data, test.key, 0, len(test.data)-1)
 		if actual != test.expected {
-			t.Errorf("test %s failed", test.name)
+			t.Errorf("test %s failed: expected '%d', get '%d'", test.name, test.expected, actual)
 		}
 	}
 }
@@ -44,7 +44,7 @@ func TestLinearSearch(t *testing.T) {
 	for _, test := range searchTests {
 		actual := linearSearch(test.data, test.key)
 		if actual != test.expected {
-			t.Errorf("test %s failed", test.name)
+			t.Errorf("test %s failed: expected '%d', get '%d'", test.name, test.expected, actual)
 		}
 	}
 }


### PR DESCRIPTION
I added test cases for binary and linear searches and I notice the `iterBinarySearch` function does not passes the test cases. I make some minor changes to the algorithm.