### PR TITLE
Fix sort testcase input sorted unintentionally

### DIFF
--- a/sorts/sorts_test.go
+++ b/sorts/sorts_test.go
@@ -7,7 +7,7 @@ import (
 func testFramework(t *testing.T, sortingFunction func([]int) []int) {
 	for _, test := range sortTests {
 		t.Run(test.name, func(t *testing.T) {
-			actual := sortingFunction(test.input)
+			actual := sortingFunction(cloneIntSlice(test.input))
 			pos, sorted := compareSlices(actual, test.expected)
 			if !sorted {
 				if pos == -1 {
@@ -63,7 +63,10 @@ func TestSelection(t *testing.T) {
 func benchmarkFramework(b *testing.B, sortingFunction func([]int) []int) {
 	for i := 0; i < b.N; i++ {
 		for _, test := range sortTests {
-			sortingFunction(test.input)
+			b.StopTimer()
+			input := cloneIntSlice(test.input)
+			b.StartTimer()
+			sortingFunction(input)
 		}
 	}
 }

--- a/sorts/sorts_test.go
+++ b/sorts/sorts_test.go
@@ -60,69 +60,39 @@ func TestSelection(t *testing.T) {
 
 //END TESTS
 
+func benchmarkFramework(b *testing.B, sortingFunction func([]int) []int) {
+	for i := 0; i < b.N; i++ {
+		for _, test := range sortTests {
+			sortingFunction(test.input)
+		}
+	}
+}
+
 func BenchmarkBubble(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			bubbleSort(test.input)
-		}
-	}
+	benchmarkFramework(b, bubbleSort)
 }
-
 func BenchmarkInsertion(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			InsertionSort(test.input)
-		}
-	}
+	benchmarkFramework(b, InsertionSort)
 }
-
 func BenchmarkMerge(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			Mergesort(test.input)
-		}
-	}
+	benchmarkFramework(b, Mergesort)
 }
-
 func BenchmarkHeap(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			HeapSort(test.input)
-		}
-	}
+	benchmarkFramework(b, HeapSort)
 }
-
 func BenchmarkQuick(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			QuickSort(test.input)
-		}
-	}
+	benchmarkFramework(b, QuickSort)
 }
-
 func BenchmarkShell(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			ShellSort(test.input)
-		}
-	}
+	benchmarkFramework(b, ShellSort)
 }
-
 func BenchmarkRadix(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			RadixSort(test.input)
-		}
-	}
+	benchmarkFramework(b, RadixSort)
 }
 
 // Very Slow, consider commenting
 func BenchmarkSelection(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		for _, test := range sortTests {
-			SelectionSort(test.input)
-		}
-	}
+	benchmarkFramework(b, SelectionSort)
 }
 
 func compareSlices(a []int, b []int) (int, bool) {

--- a/sorts/sorts_testcases.go
+++ b/sorts/sorts_testcases.go
@@ -69,6 +69,8 @@ func makeRandomSignedSlice(size int) []int {
 	return vals
 }
 
+// getSortedVersion Takes a slice of ints and returns a slice as a sorted (in 
+// ascending order) copy of the slice passed as the argument.
 func getSortedVersion(a []int) []int {
 	b := cloneIntSlice(a)
 	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })

--- a/sorts/sorts_testcases.go
+++ b/sorts/sorts_testcases.go
@@ -75,6 +75,8 @@ func getSortedVersion(a []int) []int {
 	return b
 }
 
+// cloneIntSlice returns a copy of a given slice of int.
+// Useful to protect a slice from in-place sorting functions.
 func cloneIntSlice(src []int) []int {
 	vals := make([]int, len(src))
 	copy(vals, src)

--- a/sorts/sorts_testcases.go
+++ b/sorts/sorts_testcases.go
@@ -13,8 +13,8 @@ type sortTest struct {
 	name     string
 }
 
-var uarr []int = makeRandomUnsignedSlice(500_000)
-var arr []int = makeRandomSignedSlice(500_000)
+var uarr []int = makeRandomUnsignedSlice(5_000)
+var arr []int = makeRandomSignedSlice(5_000)
 
 var sortTests = []sortTest{
 	//Sorted slice
@@ -23,7 +23,7 @@ var sortTests = []sortTest{
 	//Reversed slice
 	{[]int{10, 9, 8, 7, 6, 5, 4, 3, 2, 1},
 		[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, "Reversed Unsigned"},
-	//500k unsigned int values sort
+	//5k unsigned int values sort
 	{uarr, getSortedVersion(uarr), "Large Random Unsigned"},
 
 	//Sorted slice
@@ -42,7 +42,7 @@ var sortTests = []sortTest{
 	{[]int{-5, 7, 4, -2, 6, 5, 8, 3, 2, -7, -1, 0, -3, 9, -6, -4, 10, 9, 1, -8, -9, -10},
 		[]int{-10, -9, -8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 9, 10}, "Random order Signed"},
 
-	//500k int values sort
+	//5k int values sort
 	{arr, getSortedVersion(arr), "Large Random Signed"},
 
 	//Empty slice

--- a/sorts/sorts_testcases.go
+++ b/sorts/sorts_testcases.go
@@ -70,6 +70,13 @@ func makeRandomSignedSlice(size int) []int {
 }
 
 func getSortedVersion(a []int) []int {
-	sort.Slice(a, func(i, j int) bool { return a[i] < a[j] })
-	return a
+	b := cloneIntSlice(a)
+	sort.Slice(b, func(i, j int) bool { return b[i] < b[j] })
+	return b
+}
+
+func cloneIntSlice(src []int) []int {
+	vals := make([]int, len(src))
+	copy(vals, src)
+	return vals
 }


### PR DESCRIPTION
As `getSortedVersion` and other sorting functions modify a given slice, testcase inputs are unintentionally sorted beforehand.

To avoid that, passes a cloned slices to these functions.