### PR TITLE
fix stack overflow problem and add more test

### DIFF
--- a/searches/binarysearch.go
+++ b/searches/binarysearch.go
@@ -1,12 +1,13 @@
 package searches
 
+
 func binarySearch(array []int, target int, lowIndex int, highIndex int) int {
-	if highIndex < lowIndex {
+	if highIndex < lowIndex || len(array) == 0{
 		return -1
 	}
-	mid := int(lowIndex + (highIndex-lowIndex)/2)
+	mid := (highIndex+lowIndex)/2
 	if array[mid] > target {
-		return binarySearch(array, target, lowIndex, mid)
+		return binarySearch(array, target, lowIndex, mid-1)
 	} else if array[mid] < target {
 		return binarySearch(array, target, mid+1, highIndex)
 	} else {
@@ -18,12 +19,16 @@ func iterBinarySearch(array []int, target int, lowIndex int, highIndex int) int 
 	startIndex := lowIndex
 	endIndex := highIndex
 	var mid int
-	for startIndex < endIndex {
-		mid = int(startIndex + (endIndex - startIndex))
+	size := len(array)
+	if size ==0 || highIndex > size || lowIndex < 0 {
+		return -1
+	}
+	for startIndex <= endIndex {
+		mid = (endIndex + startIndex)/2
 		if array[mid] > target {
-			endIndex = mid
+			endIndex = mid-1
 		} else if array[mid] < target {
-			startIndex = mid
+			startIndex = mid+1
 		} else {
 			return mid
 		}

--- a/searches/search_test.go
+++ b/searches/search_test.go
@@ -11,8 +11,11 @@ type searchTest struct {
 
 var searchTests = []searchTest{
 	//Sanity
+	{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 1, 0, "Sanity"},
 	{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 5, 4, "Sanity"},
+	{[]int{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}, 10, 9, "Sanity"},
 	//Absent
+	{[]int{1, 4, 5, 6, 7, 10}, -25, -1, "Absent"},
 	{[]int{1, 4, 5, 6, 7, 10}, 25, -1, "Absent"},
 	//Empty slice
 	{[]int{}, 2, -1, "Empty"},
@@ -27,6 +30,15 @@ func TestBinarySearch(t *testing.T) {
 	}
 }
 
+func TestIterBinarySearch(t *testing.T) {
+	for _, test := range searchTests {
+		actual := iterBinarySearch(test.data, test.key, 0, len(test.data)-1)
+		if actual != test.expected {
+			t.Errorf("test %s failed", test.name)
+		}
+	}
+}
+
 func TestLinearSearch(t *testing.T) {
 	for _, test := range searchTests {
 		actual := linearSearch(test.data, test.key)
@@ -35,3 +47,4 @@ func TestLinearSearch(t *testing.T) {
 		}
 	}
 }
+


### PR DESCRIPTION
For recursive binary search code, there was a stack overflow problem when the target value is less than smallest value in the array, and the iterate version code also failed in many test cases, i fix the bug and add more test for current binary search code. 

Test result : 
 
```
=== RUN   TestBinarySearch
--- PASS: TestBinarySearch (0.00s)
=== RUN   TestIterBinarySearch
--- PASS: TestIterBinarySearch (0.00s)
=== RUN   TestLinearSearch
--- PASS: TestLinearSearch (0.00s)
PASS
```