### PR TITLE
Add lacked tests for caesar cipher

### DIFF
--- a/ciphers/caesar/CaesarCipher.go
+++ b/ciphers/caesar/CaesarCipher.go
@@ -1,41 +1,38 @@
-package ceaser
- 
-import (
-	"bytes"
-	"flag"
-	"fmt"
-	"strings"
-)
- 
-func main() {
-	cipherKey := flag.Int("c", 0, "Cipher shift amount (-26 - 26)")
-	input := flag.String("i", "", "Input")
-	flag.Parse()
- 
-	if *cipherKey > 26 || *cipherKey < -26 {
-		flag.PrintDefaults()
-	} else {
-		fmt.Println(caesarCipher(*input, *cipherKey))
-	}
- 
+// Package caesar is the shift cipher
+// ref: https://en.wikipedia.org/wiki/Caesar_cipher
+package caesar
+
+// Caesar is struct for Caesar cipher
+type Caesar struct {
 }
- 
-func caesarCipher(input string, key int) string {
-	var outputBuffer bytes.Buffer
-	for _, r := range strings.ToLower(input) {
+
+// NewCaesar returns a pointer to object of Caesar
+func NewCaesar() *Caesar {
+	return &Caesar{}
+}
+
+// Encrypt encrypts by right shift of "key" each character of "input"
+func (c Caesar) Encrypt(input string, key int) string {
+	// if key is negative value,
+	// updates "key" the number which congruents to "key" modulo 26
+	key = (key%26 + 26) % 26
+
+	outputBuffer := []byte{}
+	for _, r := range input {
 		newByte := byte(r)
- 
-		if newByte >= 'a' && newByte <= 'z' {
-			newByte += byte(key)
- 
-			if newByte > 'z' {
-				newByte -= 26
-			} else if newByte < 'a' {
-				newByte += 26
-			}	
+		if 'A' <= newByte && newByte <= 'Z' {
+			outputBuffer = append(outputBuffer, byte(int('A')+int(int(newByte-'A')+key)%26))
+		} else if 'a' <= newByte && newByte <= 'z' {
+			outputBuffer = append(outputBuffer, byte(int('a')+int(int(newByte-'a')+key)%26))
+		} else {
+			outputBuffer = append(outputBuffer, newByte)
 		}
- 
-		outputBuffer.WriteString(string(newByte))
 	}
-	return outputBuffer.String()
+	return string(outputBuffer)
+}
+
+// Decrypt decrypts by left shift of "key" each character of "input"
+func (c Caesar) Decrypt(input string, key int) string {
+	// left shift of "key" is same as right shift of 26-"key"
+	return c.Encrypt(input, 26-key)
 }

--- a/ciphers/caesar/caesar_test.go
+++ b/ciphers/caesar/caesar_test.go
@@ -1,63 +1,72 @@
-package ceaser
+package caesar_test
 
 import (
+	"TheAlgorithms/Go/ciphers/caesar"
+	"fmt"
 	"testing"
 )
 
-var caesarTestData = []struct {
-	description string
-	input       string
-	key         int
-	expected    string
-}{
-	{
-		"Basic caesar encryption with letter 'a'",
-		"a",
-		3,
-		"d",
-	},
-	{
-		"Basic caesar encryption wrap around alphabet on letter 'z'",
-		"z",
-		3,
-		"c",
-	},
-	{
-		"Encrypt a simple string with ceasar encryiption",
-		"hello",
-		3,
-		"khoor",
-	},
-	{
-		"Encrypt a simple string with key 13",
-		"hello",
-		13,
-		"uryyb",
-	},
-	{
-		"Encrypt a simple string with key -13",
-		"hello",
-		-13,
-		"uryyb",
-	},
-	{
-		"With key of 26 output should be the same as the input",
-		"no change",
-		26,
-		"no change",
-	},
-	{
-		"Encrpyt sentence with key 10",
-		"the quick brown fox jumps over the lazy dog.",
-		10,
-		"dro aesmu lbygx pyh tewzc yfob dro vkji nyq.",
-	},
-}
+var c *caesar.Caesar = caesar.NewCaesar()
 
-func TestCeasarCipher(t *testing.T) {
+func TestEncrypt(t *testing.T) {
+	var caesarTestData = []struct {
+		description string
+		input       string
+		key         int
+		expected    string
+	}{
+		{
+			"Basic caesar encryption with letter 'a'",
+			"a",
+			3,
+			"d",
+		},
+		{
+			"Basic caesar encryption wrap around alphabet on letter 'z'",
+			"z",
+			3,
+			"c",
+		},
+		{
+			"Encrypt a simple string with caesar encryiption",
+			"hello",
+			3,
+			"khoor",
+		},
+		{
+			"Encrypt a simple string with key 13",
+			"hello",
+			13,
+			"uryyb",
+		},
+		{
+			"Encrypt a simple string with key -13",
+			"hello",
+			-13,
+			"uryyb",
+		},
+		{
+			"With key of 26 output should be the same as the input",
+			"no change",
+			26,
+			"no change",
+		},
+		{
+			"Encrypt sentence with key 10",
+			"the quick brown fox jumps over the lazy dog.",
+			10,
+			"dro aesmu lbygx pyh tewzc yfob dro vkji nyq.",
+		},
+		{
+			"Encrypt sentence with key 10",
+			"The Quick Brown Fox Jumps over the Lazy Dog.",
+			10,
+			"Dro Aesmu Lbygx Pyh Tewzc yfob dro Vkji Nyq.",
+		},
+	}
 	for _, test := range caesarTestData {
 		t.Run(test.description, func(t *testing.T) {
-			actual := caesarCipher(test.input, test.key)
+			actual := c.Encrypt(test.input, test.key)
 			if actual != test.expected {
 				t.Logf("FAIL: %s", test.description)
 				t.Fatalf("With input string '%s' and key '%d' was expecting '%s' but actual was '%s'",
@@ -65,4 +74,86 @@ func TestCeasarCipher(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecrypt(t *testing.T) {
+	var caesarTestData = []struct {
+		description string
+		input       string
+		key         int
+		expected    string
+	}{
+		{
+			"Basic caesar decryption with letter 'a'",
+			"a",
+			3,
+			"x",
+		},
+		{
+			"Basic caesar decryption wrap around alphabet on letter 'z'",
+			"z",
+			3,
+			"w",
+		},
+		{
+			"Decrypt a simple string with caesar encryiption",
+			"hello",
+			3,
+			"ebiil",
+		},
+		{
+			"Decrypt a simple string with key 13",
+			"hello",
+			13,
+			"uryyb",
+		},
+		{
+			"Decrypt a simple string with key -13",
+			"hello",
+			-13,
+			"uryyb",
+		},
+		{
+			"With key of 26 output should be the same as the input",
+			"no change",
+			26,
+			"no change",
+		},
+		{
+			"Decrypt sentence with key 10",
+			"Dro Aesmu Lbygx Pyh Tewzc yfob dro Vkji Nyq.",
+			10,
+			"The Quick Brown Fox Jumps over the Lazy Dog.",
+		},
+	}
+
+	for _, test := range caesarTestData {
+		t.Run(test.description, func(t *testing.T) {
+			actual := c.Decrypt(test.input, test.key)
+			if actual != test.expected {
+				t.Logf("FAIL: %s", test.description)
+				t.Fatalf("With input string '%s' and key '%d' was expecting '%s' but actual was '%s'",
+					test.input, test.key, test.expected, actual)
+			}
+		})
+	}
+}
+
+func ExampleNewCaesar() {
+	const (
+		key   = 10
+		input = "The Quick Brown Fox Jumps over the Lazy Dog."
+	)
+
+	c := caesar.NewCaesar()
+
+	encryptedText := c.Encrypt(input, key)
+	fmt.Printf("Encrypt=> key: %d, input: %s, encryptedText: %s\n", key, input, encryptedText)
+
+	decryptedText := c.Decrypt(encryptedText, key)
+	fmt.Printf("Decrypt=> key: %d, input: %s, decryptedText: %s\n", key, encryptedText, decryptedText)
+
+	// Output:
+	// Encrypt=> key: 10, input: The Quick Brown Fox Jumps over the Lazy Dog., encryptedText: Dro Aesmu Lbygx Pyh Tewzc yfob dro Vkji Nyq.
+	// Decrypt=> key: 10, input: Dro Aesmu Lbygx Pyh Tewzc yfob dro Vkji Nyq., decryptedText: The Quick Brown Fox Jumps over the Lazy Dog.
 }


### PR DESCRIPTION
  - add lacked processings
     - adapts not only lowercase but also uppercase
     - implements decrypt function
  - fix typo
    - package name
    - some words in test
  - add lacked test cases
    - coverage(64.7%=>100.0%) 

refers: #13 #197 #260