### PR TITLE
fix rot13 content

### DIFF
--- a/ciphers/rot13/rot13.go
+++ b/ciphers/rot13/rot13.go
@@ -1,26 +1,12 @@
+// Package rot13 is a simple letter substitution cipher that replaces a letter with the 13th letter after it in the alphabet.
+// ref: https://en.wikipedia.org/wiki/ROT13
 package rot13
 
 import (
-	"bytes"
-	"strings"
+	"TheAlgorithms/Go/ciphers/caesar"
 )
 
+// rot13 is a special case, which is fixed the shift of 13, of the Caesar cipher
 func rot13(input string) string {
-	var outputBuffer bytes.Buffer
-	for _, r := range strings.ToLower(input) {
-		newByte := int(r)
-
-		if newByte >= 'a' && newByte <= 'z' {
-			newByte += 13
-
-			if newByte > 'z' {
-				newByte -= 26
-			} else if newByte < 'a' {
-				newByte += 26
-			}
-		}
-
-		outputBuffer.WriteString(string(newByte))
-	}
-	return outputBuffer.String()
+	return caesar.NewCaesar().Encrypt(input, 13)
 }


### PR DESCRIPTION
I've changed from original implementation to the way using tested "caesar" package because rot13 is a special case, which is fixed the shift of 13, of the Caesar cipher. 
ref: https://en.wikipedia.org/wiki/ROT13

Package rot13 has error below on testing.

```
$ go test -v -parallel=4 -covermode=atomic ./ciphers/rot13/...
# TheAlgorithms/Go/ciphers/rot13
ciphers/rot13/rot13.go:23: conversion from int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
FAIL    TheAlgorithms/Go/ciphers/rot13 [build failed]
FAIL
```

Containing this package into "caesar" package is also one of the way to fix this error. If this way is preferable, I will fix this pull request.