### PR TITLE
adding openaddress hashtable

### DIFF
--- a/datastructures/hashmap/hashtable.go
+++ b/datastructures/hashmap/hashtable.go
@@ -1,0 +1,17 @@
+package hashmap
+
+// HashTable represents a hash table interface
+type HashTable interface {
+	// Put will insert value with key
+	Put(key interface{}, value interface{})
+
+	// Get : returns value of a given key
+	// return nil if key doesn't exists
+	Get(key interface{}) interface{}
+
+	// Delete : remove the key from the table
+	Delete(key interface{})
+
+	// Contains : return true if given exists in table and false otherwise
+	Contains(key interface{}) bool
+}

--- a/datastructures/hashmap/hashtable.go
+++ b/datastructures/hashmap/hashtable.go
@@ -14,4 +14,15 @@ type HashTable interface {
 
 	// Contains : return true if given exists in table and false otherwise
 	Contains(key interface{}) bool
+
+	// Len : returns length of the hash table
+	Len() int
+
+	// Cap : returns current capacity of the hash table
+	Cap() int
+}
+
+// NewHashTable : creates new HashTable
+func NewHashTable() HashTable {
+	return newTable()
 }

--- a/datastructures/hashmap/withProbing.go
+++ b/datastructures/hashmap/withProbing.go
@@ -1,3 +1,5 @@
+// Package hashmap provide hash table implementation with collsion resolved
+// using openaddressing
 package hashmap
 
 import (
@@ -24,6 +26,7 @@ type table struct {
 	capacity uint64 // cap = 2^m
 }
 
+// newTable is internal function for creating new hash table
 func newTable() *table {
 	return &table{
 		buckets:  make([]*entry, 1<<initMValue),
@@ -53,6 +56,14 @@ func (t *table) Put(key interface{}, value interface{}) {
 		t.buckets[index].value = value
 	}
 }
+
+func (t *table) Len() int {
+	return int(t.size)
+}
+func (t *table) Cap() int {
+	return int(t.capacity)
+}
+
 func (t *table) Get(key interface{}) interface{} {
 	encoded := encode(key)
 	hashed := t.hash(encoded)

--- a/datastructures/hashmap/withProbing.go
+++ b/datastructures/hashmap/withProbing.go
@@ -1,0 +1,137 @@
+package hashmap
+
+import (
+	"fmt"
+	"math"
+)
+
+const (
+	goldenRatio     float64 = 1.618033988749895
+	radix                   = uint64('~' - ' ')
+	loadFactor      float64 = 0.667
+	initMValue              = 1
+	deletedEntryKey         = "U+0000"
+)
+
+type entry struct {
+	key   interface{}
+	value interface{}
+}
+type table struct {
+	buckets  []*entry
+	size     uint64
+	m        uint64
+	capacity uint64 // cap = 2^m
+}
+
+func newTable() *table {
+	return &table{
+		buckets:  make([]*entry, 1<<initMValue),
+		size:     0,
+		m:        uint64(initMValue),
+		capacity: uint64(1 << initMValue),
+	}
+}
+func (t *table) Put(key interface{}, value interface{}) {
+	if t.size > uint64(loadFactor*float64(t.capacity)) {
+		t.resize(t.m + 1)
+	}
+	encoded := encode(key)
+	hashed := t.hash(encoded)
+	index := hashed
+	var trail uint64 = 1
+	for ; t.buckets[index] != nil && t.buckets[index].key != key; trail++ {
+		// fmt.Println("key=", key, "index=", index, "trail=", trail)
+		index = (hashed + (trail * t.probe(encoded))) % t.capacity
+	}
+	if t.buckets[index] == nil {
+		t.buckets[index] = &entry{
+			key:   key,
+			value: value,
+		}
+		t.size++
+	} else {
+		t.buckets[index].value = value
+	}
+}
+func (t *table) Get(key interface{}) interface{} {
+	encoded := encode(key)
+	hashed := t.hash(encoded)
+	index := hashed
+	var trail uint64 = 1
+	for ; t.buckets[index] != nil && t.buckets[index].key != deletedEntryKey; trail++ {
+		if t.buckets[index].key == key {
+			return t.buckets[index].value
+		}
+		index = (hashed + (trail * t.probe(encoded))) % t.capacity
+	}
+	return nil
+}
+func (t *table) Delete(key interface{}) {
+	encoded := encode(key)
+	hashed := t.hash(encoded)
+	index := hashed
+	var trail uint64 = 1
+	for ; t.buckets[index] != nil; trail++ {
+		if t.buckets[index].key == key {
+			t.buckets[index].key = deletedEntryKey
+			t.buckets[index].value = nil
+			t.size--
+			break
+		}
+		index = (hashed + (trail * t.probe(encoded))) % t.capacity
+	}
+	if t.size <= t.capacity/4 {
+		t.resize(t.m - 1)
+	}
+}
+func (t *table) Contains(key interface{}) bool {
+	return t.Get(key) != nil
+}
+
+func (t *table) resize(newM uint64) {
+	t.m = newM
+	t.capacity = 1 << newM
+	var encoded uint64
+	var hashed uint64
+	var index uint64
+	var trail uint64
+	newBuckets := make([]*entry, int(t.capacity), int(t.capacity))
+	for _, v := range t.buckets {
+		if v != nil && v.key != deletedEntryKey {
+			encoded = encode(v.key)
+			hashed = t.hash(encoded)
+			trail = 1
+			index = hashed
+			for ; newBuckets[index] != nil; trail++ {
+				index = (hashed + (trail * t.probe(encoded))) % t.capacity
+			}
+			newBuckets[index] = v
+		}
+	}
+	t.buckets = nil
+	t.buckets = newBuckets
+}
+
+// linear probing
+func (t *table) probe(encoded uint64) uint64 {
+	return 7
+}
+
+// encode converts a key of any type to a uint64 number
+func encode(key interface{}) uint64 {
+	var out uint64
+	for _, v := range fmt.Sprintf("%v", key) {
+		out = uint64(v) + radix*out
+	}
+	return out
+}
+
+// Multiplication Based hashing
+// M (table size) = 2^m
+func (t *table) hash(encoded uint64) uint64 {
+	// aK : is golden ratio multiplied with encode key
+	aK := goldenRatio * float64(encoded)
+	// hash based on Multiplication
+	return uint64((aK - math.Floor(aK)) * float64(t.capacity))
+}

--- a/datastructures/hashmap/withProbing.go
+++ b/datastructures/hashmap/withProbing.go
@@ -41,7 +41,6 @@ func (t *table) Put(key interface{}, value interface{}) {
 	index := hashed
 	var trail uint64 = 1
 	for ; t.buckets[index] != nil && t.buckets[index].key != key; trail++ {
-		// fmt.Println("key=", key, "index=", index, "trail=", trail)
 		index = (hashed + (trail * t.probe(encoded))) % t.capacity
 	}
 	if t.buckets[index] == nil {
@@ -96,7 +95,7 @@ func (t *table) resize(newM uint64) {
 	var hashed uint64
 	var index uint64
 	var trail uint64
-	newBuckets := make([]*entry, int(t.capacity), int(t.capacity))
+	newBuckets := make([]*entry, int(t.capacity))
 	for _, v := range t.buckets {
 		if v != nil && v.key != deletedEntryKey {
 			encoded = encode(v.key)

--- a/datastructures/hashmap/withProbing_test.go
+++ b/datastructures/hashmap/withProbing_test.go
@@ -91,7 +91,7 @@ func BenchmarkGoPut(b *testing.B) {
 }
 
 // Put Benchmark on HashTable with Collision Handled via Chaining
-func BenchmarkOldPut(b *testing.B) {
+func BenchmarkChainingPut(b *testing.B) {
 	tb := New()
 	for i := 0; i < b.N; i++ {
 		tb.Put(i, i)

--- a/datastructures/hashmap/withProbing_test.go
+++ b/datastructures/hashmap/withProbing_test.go
@@ -1,0 +1,99 @@
+package hashmap
+
+import (
+	"testing"
+)
+
+func TestHashTable(t *testing.T) {
+
+	mp := newTable()
+
+	t.Run("Test 1: Put(10) and checking if Get() is correct", func(t *testing.T) {
+		mp.Put("test", 10)
+		got := mp.Get("test")
+		if got != 10 {
+			t.Errorf("Put: %v, Got: %v", 10, got)
+		}
+	})
+
+	t.Run("Test 2: Reassiging the value and checking if its correct", func(t *testing.T) {
+		mp.Put("test", 20)
+		got := mp.Get("test")
+		if got != 20 {
+			t.Errorf("Put (reassign): %v, Got: %v", 20, got)
+		}
+	})
+
+	t.Run("Test 3: Adding new key when there is already some data", func(t *testing.T) {
+		mp.Put("test2", 30)
+		got := mp.Get("test2")
+		if got != 30 {
+			t.Errorf("Put: %v, Got: %v", got, 30)
+		}
+	})
+
+	t.Run("Test 4: Adding numeric key", func(t *testing.T) {
+		mp.Put(1, 40)
+		got := mp.Get(1)
+		if got != 40 {
+			t.Errorf("Put: %v, Got: %v", got, 40)
+		}
+	})
+
+	t.Run("Test 5: Checking the Contains function", func(t *testing.T) {
+		want := true
+		got := mp.Contains(1)
+		if want != got {
+			t.Errorf("Key '1' exists but couldn't be retrieved")
+		}
+	})
+
+	t.Run("Test 6: Checking if the key that doesnt exists returns false", func(t *testing.T) {
+		want := false
+		got := mp.Contains(2)
+		if got != want {
+			t.Errorf("Key '2' doesn't exists in the map but it says otherwise")
+		}
+	})
+	t.Run("Test 7: Checking deleted key exists or not", func(t *testing.T) {
+		want := false
+		mp.Delete(2)
+		got := mp.Contains(2)
+		if got != want {
+			t.Errorf("Key '2' deleted from table but it says otherwise")
+		}
+	})
+	t.Run("Test 8: HashTable Implement table interface", func(t *testing.T) {
+		want := true
+		var l interface{} = newTable()
+		_, got := l.(HashTable)
+		if got != want {
+			t.Errorf("table should implement HashTable interface but it say otherwise")
+		}
+	})
+
+}
+
+// Put Benchmark on HashTable with Collision Handled via openaddress
+func BenchmarkOpenAddresPut(b *testing.B) {
+	tb := newTable()
+	for i := 0; i < b.N; i++ {
+		tb.Put(i, i)
+	}
+}
+
+// Go map Put benchmark
+func BenchmarkGoPut(b *testing.B) {
+	tb := make(map[interface{}]interface{}, 2)
+	for i := 0; i < b.N; i++ {
+		tb[i] = i
+	}
+}
+
+// Put Benchmark on HashTable with Collision Handled via Chaining
+func BenchmarkOldPut(b *testing.B) {
+	tb := New()
+	for i := 0; i < b.N; i++ {
+		tb.Put(i, i)
+	}
+}


### PR DESCRIPTION
Added Following things
- Hash Table interface
```
// HashTable represents a hash table interface
type HashTable interface {
	// Put will insert value with key
	Put(key interface{}, value interface{})

	// Get : returns value of a given key
	// return nil if key doesn't exists
	Get(key interface{}) interface{}

	// Delete : remove the key from the table
	Delete(key interface{})

	// Contains : return true if given exists in table and false otherwise
	Contains(key interface{}) bool
}
```
- Collision resolved with open-addressing (linear)
- Added Benchmark
```
Hash Table With Chaining :
BenchmarkChainingPut-4               10000            209244 ns/op          859210 B/op         22 allocs/op
Hash Table With open addressing:
BenchmarkOpenAddresPut-4             1000000              3704 ns/op              99 B/op          5 allocs/op
Go in-build map
BenchmarkGoPut-4                   2091596               598 ns/op             171 B/op          2 allocs/op
  ```
Signed-off-by: Zzocker <pkspritam16@gmail.com>