### PR TITLE
Patch action Godocmd

### DIFF
--- a/.github/workflows/godocmd.yml
+++ b/.github/workflows/godocmd.yml
@@ -1,5 +1,8 @@
 name: godocmd
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
 jobs:
   generate_readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The godocmd action triggers an update on the branch but an action doesn't trigger an event and therefore if the new changes are pushed to the branch, no new actions will run - this includes golangci-lint-and-test action that we have which is a `required` action for all PRs and  must satisfy this so it gets stuck in this because it will never get triggered 😓. The immediate fix is that the PR would not trigger this action, instead when the merge happens the action would be triggered and it would run as expected. Although, there is a possibility that this might not work because the master branch is protected and the push to master fails. This related to #407 