### PR TITLE
fix: only to run when push happens - upstream master is protected but not the forks master

### DIFF
--- a/.github/workflows/godocmd.yml
+++ b/.github/workflows/godocmd.yml
@@ -1,5 +1,5 @@
 name: godocmd
-on: [push, pull_request]
+on: [push]
 jobs:
   generate_readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As the title suggests, currently some actions were failing and the issue is because the checkout was happening in detached state. The fetch-depth 0 fixes that and the only problem afterwards is that the master is protected (as it should be) so on pull_requests the action would always fail. Therefore, I moved it to push only so that when the push occurs in forks it should run to create the documentation. Sorry about the multiple PRs, my local rebase became messy and tbh both cherry picking rebasing is difficult for me.