### PR TITLE
feat: add math/MontecarloPi2 implementation

### DIFF
--- a/math/pi/montecarlopi.go
+++ b/math/pi/montecarlopi.go
@@ -8,7 +8,9 @@
 package pi
 
 import (
+	"fmt"
 	"math/rand"
+	"runtime"
 	"time"
 )
 
@@ -24,4 +26,54 @@ func MonteCarloPi(randomPoints int) float64 {
 	}
 	pi := float64(inside) / float64(randomPoints) * 4
 	return pi
+}
+
+func MonteCarloPi2(n int) (float64, error) {
+	numCPU := runtime.GOMAXPROCS(0)
+	c := make(chan int, numCPU)
+	pointsToDraw, err := splitInt(n, numCPU)
+	if err != nil {
+		return 0, err
+	}
+	for _, p := range pointsToDraw {
+		go drawPoints(p, c)
+	}
+	inside := 0
+	for i := 0; i < numCPU; i++ {
+		inside += <-c
+	}
+	return float64(inside) / float64(n) * 4, nil
+}
+
+func drawPoints(n int, c chan<- int) {
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	inside := 0
+	for i := 0; i < n; i++ {
+		x, y := rnd.Float64(), rnd.Float64()
+		if x*x+y*y <= 1 {
+			inside++
+		}
+	}
+	c <- inside
+}
+
+func splitInt(x int, n int) ([]int, error) {
+	if x < n {
+		return nil, fmt.Errorf("x must be < n - given values are x=%d, n=%d", x, n)
+	}
+	split := make([]int, n)
+	if x%n == 0 {
+		for i := 0; i < n; i++ {
+			split[i] = x / n
+		}
+	} else {
+		limit := x % n
+		for i := 0; i < limit; i++ {
+			split[i] = x/n + 1
+		}
+		for i := limit; i < n; i++ {
+			split[i] = x / n
+		}
+	}
+	return split, nil
 }

--- a/math/pi/montecarlopi.go
+++ b/math/pi/montecarlopi.go
@@ -28,12 +28,12 @@ func MonteCarloPi(randomPoints int) float64 {
 	return pi
 }
 
-// MonteCarloPi2 approximates the value of pi using the Monte Carlo method.
+// MonteCarloPiConcurrent approximates the value of pi using the Monte Carlo method.
 // Unlike the MonteCarloPi function (first version), this implementation uses
 // goroutines and channels to parallelize the computation.
 // More details on the Monte Carlo method available at https://en.wikipedia.org/wiki/Monte_Carlo_method.
 // More details on goroutines parallelization available at https://go.dev/doc/effective_go#parallel.
-func MonteCarloPi2(n int) (float64, error) {
+func MonteCarloPiConcurrent(n int) (float64, error) {
 	numCPU := runtime.GOMAXPROCS(0)
 	c := make(chan int, numCPU)
 	pointsToDraw, err := splitInt(n, numCPU) // split the task in sub-tasks of approximately equal sizes

--- a/math/pi/montecarlopi.go
+++ b/math/pi/montecarlopi.go
@@ -1,17 +1,17 @@
 // montecarlopi.go
 // description: Calculating pi by the Monte Carlo method
 // details:
-// implementation of Monte Carlo Algorithm for the calculating of Pi - [Monte Carlo method](https://en.wikipedia.org/wiki/Monte_Carlo_method)
-// author(s) [red_byte](https://github.com/i-redbyte)
+// implementations of Monte Carlo Algorithm for the calculating of Pi - [Monte Carlo method](https://en.wikipedia.org/wiki/Monte_Carlo_method)
+// author(s): [red_byte](https://github.com/i-redbyte), [Paul Leydier] (https://github.com/paul-leydier)
 // see montecarlopi_test.go
 
 package pi
 
 import (
-	"fmt"
-	"math/rand"
-	"runtime"
-	"time"
+	"fmt"       // Used for error formatting
+	"math/rand" // Used for random number generation in Monte Carlo method
+	"runtime"   // Used to get information on available CPUs
+	"time"      // Used for seeding the random number generation
 )
 
 func MonteCarloPi(randomPoints int) float64 {
@@ -28,16 +28,25 @@ func MonteCarloPi(randomPoints int) float64 {
 	return pi
 }
 
+// MonteCarloPi2 approximates the value of pi using the Monte Carlo method.
+// Unlike the MonteCarloPi function (first version), this implementation uses
+// goroutines and channels to parallelize the computation.
+// More details on the Monte Carlo method available at https://en.wikipedia.org/wiki/Monte_Carlo_method.
+// More details on goroutines parallelization available at https://go.dev/doc/effective_go#parallel.
 func MonteCarloPi2(n int) (float64, error) {
 	numCPU := runtime.GOMAXPROCS(0)
 	c := make(chan int, numCPU)
-	pointsToDraw, err := splitInt(n, numCPU)
+	pointsToDraw, err := splitInt(n, numCPU) // split the task in sub-tasks of approximately equal sizes
 	if err != nil {
 		return 0, err
 	}
+
+	// launch numCPU parallel tasks
 	for _, p := range pointsToDraw {
 		go drawPoints(p, c)
 	}
+
+	// collect the tasks results
 	inside := 0
 	for i := 0; i < numCPU; i++ {
 		inside += <-c
@@ -45,6 +54,8 @@ func MonteCarloPi2(n int) (float64, error) {
 	return float64(inside) / float64(n) * 4, nil
 }
 
+// drawPoints draws n random two-dimensional points in the interval [0, 1), [0, 1) and sends through c
+// the number of points which where within the circle of center 0 and radius 1 (unit circle)
 func drawPoints(n int, c chan<- int) {
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	inside := 0
@@ -57,6 +68,9 @@ func drawPoints(n int, c chan<- int) {
 	c <- inside
 }
 
+// splitInt takes an integer x and splits it within an integer slice of length n in the most uniform
+// way possible.
+// For example, splitInt(10, 3) will retun []int{4, 3, 3}, nil
 func splitInt(x int, n int) ([]int, error) {
 	if x < n {
 		return nil, fmt.Errorf("x must be < n - given values are x=%d, n=%d", x, n)

--- a/math/pi/montecarlopi.go
+++ b/math/pi/montecarlopi.go
@@ -70,7 +70,7 @@ func drawPoints(n int, c chan<- int) {
 
 // splitInt takes an integer x and splits it within an integer slice of length n in the most uniform
 // way possible.
-// For example, splitInt(10, 3) will retun []int{4, 3, 3}, nil
+// For example, splitInt(10, 3) will return []int{4, 3, 3}, nil
 func splitInt(x int, n int) ([]int, error) {
 	if x < n {
 		return nil, fmt.Errorf("x must be < n - given values are x=%d, n=%d", x, n)

--- a/math/pi/montecarlopi_test.go
+++ b/math/pi/montecarlopi_test.go
@@ -25,3 +25,59 @@ func BenchmarkMonteCarloPi(b *testing.B) {
 		MonteCarloPi(100000000)
 	}
 }
+
+func TestSplitInt(t *testing.T) {
+	testCases := []struct {
+		name           string
+		x              int
+		n              int
+		expectedResult []int
+		expectedError  bool
+	}{
+		{"multiple", 10, 5, []int{2, 2, 2, 2, 2}, false},
+		{"n=1", 10, 1, []int{10}, false},
+		{"x=10, n=3", 10, 3, []int{4, 3, 3}, false},
+		{"x=10, n=7", 10, 7, []int{2, 2, 2, 1, 1, 1, 1}, false},
+		{"n>x", 10, 11, nil, true},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			res, err := splitInt(testCase.x, testCase.n)
+			for i := 0; i < len(testCase.expectedResult); i++ {
+				if res[i] != testCase.expectedResult[i] {
+					t.Fatalf("unexpected result at index %d: %d - expected %d", i, res[i], testCase.expectedResult[i])
+				}
+			}
+			if testCase.expectedError {
+				if err == nil {
+					t.Fatal("expected an error, got nil")
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("unexpected error - %s", err)
+				}
+			}
+		})
+	}
+}
+
+func TestMonteCarloPi2(t *testing.T) {
+	res, err := MonteCarloPi2(100000000)
+	if err != nil {
+		t.Errorf("unexpected error %s", err)
+	}
+	result := fmt.Sprintf("%.2f", res)
+	t.Log(result)
+	if result != "3.14" {
+		t.Errorf("Wrong result! Expected:%f, returned:%s ", 3.1415, result)
+	}
+}
+
+func BenchmarkMonteCarloPi2(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, err := MonteCarloPi2(100000000)
+		if err != nil {
+			b.Fatalf("unexpected error - %s", err)
+		}
+	}
+}

--- a/math/pi/montecarlopi_test.go
+++ b/math/pi/montecarlopi_test.go
@@ -62,7 +62,7 @@ func TestSplitInt(t *testing.T) {
 }
 
 func TestMonteCarloPi2(t *testing.T) {
-	res, err := MonteCarloPi2(100000000)
+	res, err := MonteCarloPiConcurrent(100000000)
 	if err != nil {
 		t.Errorf("unexpected error %s", err)
 	}
@@ -75,7 +75,7 @@ func TestMonteCarloPi2(t *testing.T) {
 
 func BenchmarkMonteCarloPi2(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_, err := MonteCarloPi2(100000000)
+		_, err := MonteCarloPiConcurrent(100000000)
 		if err != nil {
 			b.Fatalf("unexpected error - %s", err)
 		}


### PR DESCRIPTION
Hi everyone!

I suggest a second implementation, inspired by @i-redbyte's implementation of a Monte Carlo method for pi approximation in Go. This new implementation builds on the first one, but makes use of the goroutines and channels features of Go, in order to parallelize the computation.

The speed is the largely increased, allowing full use of the computer's multiprocessing capabilities.

---

Here are the benchmarks ran on my machine:

## Previous implementation

```
goos: windows
goarch: amd64
pkg: github.com/TheAlgorithms/Go/math/pi
cpu: Intel(R) Core(TM) i5-9600K CPU @ 3.70GHz
BenchmarkMonteCarloPi
BenchmarkMonteCarloPi-6   	       2	 613621650 ns/op
```

## New implementation

```
goos: windows
goarch: amd64
pkg: github.com/TheAlgorithms/Go/math/pi
cpu: Intel(R) Core(TM) i5-9600K CPU @ 3.70GHz
BenchmarkMonteCarloPi2
BenchmarkMonteCarloPi2-6   	      10	 102899830 ns/op
```

Let me know what you think!