### PR TITLE
DO NOT MERGE Example of Generics in Sorting Function

### DIFF
--- a/sort/bubblesort.go
+++ b/sort/bubblesort.go
@@ -5,11 +5,7 @@ package sort
 
 import "constraints"
 
-type Numbers interface {
-	~contstraints.Integer | ~constraints.Float
-}
-
-func bubbleSort[T Numbers](arr []T) []T {
+func bubbleSort[T constraints.Ordered](arr []T) []T {
 	swapped := true
 	for swapped {
 		swapped = false

--- a/sort/bubblesort.go
+++ b/sort/bubblesort.go
@@ -5,7 +5,6 @@ package sort
 
 import "constraints"
 
-
 type Numbers interface {
 	~contstraints.Integer | ~constraints.Float
 }

--- a/sort/bubblesort.go
+++ b/sort/bubblesort.go
@@ -3,7 +3,14 @@
 
 package sort
 
-func bubbleSort(arr []int) []int {
+import "constraints"
+
+
+type Numbers interface {
+	~contstraints.Integer | ~constraints.Float
+}
+
+func bubbleSort[T Numbers](arr []T) []T {
 	swapped := true
 	for swapped {
 		swapped = false


### PR DESCRIPTION
This PR serves as an example of how generics could look in in the sorting package. This code compiles with `golang1.18Beta`. Note that the `Numbers` constraint is not currently in the standard package but is being considered.

Link to full file: https://github.com/ChiefMateStarbuck/Go-1/blob/master/sort/bubblesort.go