### PR TITLE
Simplify BreadthFirstSearch.go

### DIFF
--- a/graph/breadthfirstsearch.go
+++ b/graph/breadthfirstsearch.go
@@ -13,9 +13,7 @@ func BreadthFirstSearch(start, end, nodes int, edges [][]int) (isConnected bool,
 	queue = append(queue, start)
 	for len(queue) > 0 {
 		v := queue[0]
-		if len(queue) > 0 {
-			queue = queue[1:]
-		}
+		queue = queue[1:]
 		for i := 0; i < len(edges[v]); i++ {
 			if discovered[i] == 0 && edges[v][i] > 0 {
 				if i == end {


### PR DESCRIPTION
Remove redundant if clause which condition is always met at line of execution

The condition of the for loop and the if clause are identical, so the condition of the if clause will always be met

I would suggest refactoring line 15,16 to
`v, queue := queue[0], queue[1:]` 
as well, but perhaps it is better to keep it simpler.