### PR TITLE
feat: Fuzzing test on Base64 encoding and decoding

### DIFF
--- a/conversion/base64_test.go
+++ b/conversion/base64_test.go
@@ -109,3 +109,15 @@ func TestBase64EncodeDecodeInverse(t *testing.T) {
 		}
 	}
 }
+
+func FuzzBase64Encode(f *testing.F) {
+	f.Add([]byte("hello"))
+	f.Fuzz(func(t *testing.T, input []byte) {
+		result := Base64Decode(Base64Encode(input))
+		for i := 0; i < len(input); i++ {
+			if result[i] != input[i] {
+				t.Fatalf("with input '%s' - expected '%s', got '%s' (mismatch at position %d)", input, input, result, i)
+			}
+		}
+	})
+}


### PR DESCRIPTION
As discussed in #480 , with the new Go version (1.18), we can now start adding Fuzzing tests to some of our algorithms.

This is my first try at this feature, so I would like your opinion on the code, and wheen it'll look good to you, I can work on implementing fuzzing tests on other algorithms.

To run this fuzzing test:
```
cd conversion
go test -fuzz FuzzBase64Encode
```
It'll run indefinitely by default, you can stop it with ctrl+c.

Example output:
```
fuzz: elapsed: 0s, gathering baseline coverage: 0/15 completed
fuzz: elapsed: 0s, gathering baseline coverage: 15/15 completed, now fuzzing with 12 workers
fuzz: elapsed: 3s, execs: 445059 (148282/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 6s, execs: 946614 (167085/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 9s, execs: 1453798 (168859/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 12s, execs: 1960814 (168923/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 15s, execs: 2468164 (168982/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 18s, execs: 2972295 (168527/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 21s, execs: 3478535 (168796/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 24s, execs: 3982537 (168027/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 27s, execs: 4487069 (168199/sec), new interesting: 0 (total: 14)
fuzz: elapsed: 28s, execs: 4647720 (153165/sec), new interesting: 0 (total: 14)
PASS
ok      github.com/TheAlgorithms/Go/conversion  28.614s
```