### PR TITLE
Fix: segmenttree algorithm bug

### DIFF
--- a/structure/segmenttree/segmenttree.go
+++ b/structure/segmenttree/segmenttree.go
@@ -11,7 +11,7 @@ import (
 	"github.com/TheAlgorithms/Go/math/min"
 )
 
-const emptyLazyNode = -1
+const emptyLazyNode = 0
 
 //SegmentTree with original Array and the Segment Tree Array
 type SegmentTree struct {
@@ -29,11 +29,12 @@ func (s *SegmentTree) Propagate(node int, leftNode int, rightNode int) {
 
 		if leftNode == rightNode {
 			//leaf node
-			s.Array[leftNode] = s.LazyTree[node]
+			s.Array[leftNode] += s.LazyTree[node]
 		} else {
 			//propagate lazy node value for children nodes
-			s.LazyTree[2*node] = s.LazyTree[node]
-			s.LazyTree[2*node+1] = s.LazyTree[node]
+			//may propagate multiple times, children nodes should accumulate lazy node value
+			s.LazyTree[2*node] += s.LazyTree[node]
+			s.LazyTree[2*node+1] += s.LazyTree[node]
 		}
 
 		//clear lazy node
@@ -81,7 +82,8 @@ func (s *SegmentTree) Update(node int, leftNode int, rightNode int, firstIndex i
 
 	if (leftNode >= firstIndex) && (rightNode <= lastIndex) {
 		//inside the interval
-		s.LazyTree[node] = value
+		//acumulate the lazy node value
+		s.LazyTree[node] += value
 		s.Propagate(node, leftNode, rightNode)
 	} else {
 		//update left and right nodes

--- a/structure/segmenttree/segmenttree.go
+++ b/structure/segmenttree/segmenttree.go
@@ -82,7 +82,7 @@ func (s *SegmentTree) Update(node int, leftNode int, rightNode int, firstIndex i
 
 	if (leftNode >= firstIndex) && (rightNode <= lastIndex) {
 		//inside the interval
-		//acumulate the lazy node value
+		//accumulate the lazy node value
 		s.LazyTree[node] += value
 		s.Propagate(node, leftNode, rightNode)
 	} else {

--- a/structure/segmenttree/segmenttree_test.go
+++ b/structure/segmenttree/segmenttree_test.go
@@ -60,6 +60,14 @@ func TestSegmentTree(t *testing.T) {
 			queries:  []query{{0, 5}, {0, 2}, {2, 4}},
 			expected: []int{31, 14, 24},
 		},
+		{
+			description: "test array with size 11 and range updates",
+			array: []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			updates: []update{{firstIndex: 2, lastIndex: 8, value: 2},
+				{firstIndex: 2, lastIndex: 8, value: 2}},
+			queries: []query{{3, 5}, {7, 8}, {4, 5}, {8, 8}},
+			expected: []int{15, 10, 10, 5},
+		},
 	}
 	for _, test := range segmentTreeTestData {
 		t.Run(test.description, func(t *testing.T) {


### PR DESCRIPTION
Lazy node value should be accumulated during propagation, because an interval can be updated multiple times.