### PR TITLE
segmenttree: format test file with `gofmt`

### DIFF
--- a/structure/segmenttree/segmenttree_test.go
+++ b/structure/segmenttree/segmenttree_test.go
@@ -62,10 +62,10 @@ func TestSegmentTree(t *testing.T) {
 		},
 		{
 			description: "test array with size 11 and range updates",
-			array: []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+			array:       []int{1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
 			updates: []update{{firstIndex: 2, lastIndex: 8, value: 2},
 				{firstIndex: 2, lastIndex: 8, value: 2}},
-			queries: []query{{3, 5}, {7, 8}, {4, 5}, {8, 8}},
+			queries:  []query{{3, 5}, {7, 8}, {4, 5}, {8, 8}},
 			expected: []int{15, 10, 10, 5},
 		},
 	}


### PR DESCRIPTION
Linter tests are failing as the `segmenttree_test.go` (#497) file was not properly formatted. Fixed.