### PR TITLE
add abbreviation problem in dynamic

### DIFF
--- a/dynamic/abbreviation.go
+++ b/dynamic/abbreviation.go
@@ -20,7 +20,7 @@ import (
 	"strings"
 )
 
-// Returns true if it is possible to make a equals b, returns false otherwise
+// Returns true if it is possible to make a equals b (if b is an abbreviation of a), returns false otherwise
 func Abbreviation(a string, b string) bool {
 	dp := make([][]bool, len(a)+1)
 	for i := range dp {

--- a/dynamic/abbreviation.go
+++ b/dynamic/abbreviation.go
@@ -1,0 +1,45 @@
+// File: abbreviation.go
+// Description: Abbreviation problem
+// Details:
+//   https://www.hackerrank.com/challenges/abbr/problem
+// Problem description (from hackerrank):
+//   You can perform the following operations on the string, a:
+//   1. Capitalize zero or more of a's lowercase letters.
+//   2. Delete all of the remaining lowercase letters in a.
+//   Given 2 strings a and b, determine if it's possible to make a equal to be using above operations.
+// Example:
+//	 Given a = "ABcde" and b = "ABCD"
+//   We can capitalize "c" and "d" in a to get "ABCde" then delete all the lowercase letters (which is only "e") in a to get "ABCD" which equals b.
+// Author: [duongoku](https://github.com/duongoku)
+// See abbreviation_test.go for test cases
+
+package dynamic
+
+// strings for getting uppercases and lowercases
+import (
+	"strings"
+)
+
+// Returns true if it is possible to make a equals b, returns false otherwise
+func Abbreviation(a string, b string) bool {
+	dp := make([][]bool, len(a)+1)
+	for i := range dp {
+		dp[i] = make([]bool, len(b)+1)
+	}
+	dp[0][0] = true
+
+	for i := 0; i < len(a); i++ {
+		for j := 0; j <= len(b); j++ {
+			if dp[i][j] {
+				if j < len(b) && strings.ToUpper(string(a[i])) == string(b[j]) {
+					dp[i+1][j+1] = true
+				}
+				if string(a[i]) == strings.ToLower(string(a[i])) {
+					dp[i+1][j] = true
+				}
+			}
+		}
+	}
+
+	return dp[len(a)][len(b)]
+}

--- a/dynamic/abbreviation_test.go
+++ b/dynamic/abbreviation_test.go
@@ -6,45 +6,35 @@ import (
 )
 
 func TestAbbreviation(t *testing.T) {
-	aStrings := []string{
-		"uOHlGMdUBc",
-		"kotgDIUagj",
-		"WPTffVkSNl",
-		"CoJsPURrVX",
-		"xasreDHndqvCnFfX",
-		"XFEaWCxpeepGjOnCCsFh",
-		"",
-		"a",
-		"a",
-		"a",
-		"A",
+	tests := []struct {
+		a        string
+		b        string
+		expected bool
+	}{
+		{"uOHlGMdUBc", "uOalGMdUBCasdcavsdf", false},
+		{"kotgDIUagj", "DIU", true},
+		{"WPTffVkSNl", "WPTVSN", true},
+		{"CoJsPURrVX", "CPUVX", false},
+		{"xasreDHndqvCnFfX", "DHndqvCnFX", false},
+		{"XFEaWCxpeepGjOnCCsFh", "XFEAWCPEPGOCCSF", true},
+		{"", "", true},
+		{"a", "", true},
+		{"a", "b", false},
+		{"a", "a", false},
+		{"A", "A", true},
 	}
-	bStrings := []string{
-		"uOalGMdUBCasdcavsdf",
-		"DIU",
-		"WPTVSN",
-		"CPUVX",
-		"DHndqvCnFX",
-		"XFEAWCPEPGOCCSF",
-		"",
-		"",
-		"b",
-		"a",
-		"A",
-	}
-	expected := []bool{false, true, true, false, false, true, true, true, false, false, true}
-	count := len(aStrings)
+	count := len(tests)
 	for i := 0; i < count; i++ {
 		name := fmt.Sprintf(
 			"Test case #%d: string a = \"%s\", string b = \"%s\"",
 			i+1,
-			aStrings[i],
-			bStrings[i],
+			tests[i].a,
+			tests[i].b,
 		)
 		t.Run(name, func(t *testing.T) {
-			result := Abbreviation(aStrings[i], bStrings[i])
-			if result != expected[i] {
-				t.Errorf("Expected the %t, got %t", expected[i], result)
+			result := Abbreviation(tests[i].a, tests[i].b)
+			if result != tests[i].expected {
+				t.Errorf("Expected the %t, got %t", tests[i].expected, result)
 			}
 		})
 	}

--- a/dynamic/abbreviation_test.go
+++ b/dynamic/abbreviation_test.go
@@ -1,0 +1,51 @@
+package dynamic
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestAbbreviation(t *testing.T) {
+	aStrings := []string{
+		"uOHlGMdUBc",
+		"kotgDIUagj",
+		"WPTffVkSNl",
+		"CoJsPURrVX",
+		"xasreDHndqvCnFfX",
+		"XFEaWCxpeepGjOnCCsFh",
+		"",
+		"a",
+		"a",
+		"a",
+		"A",
+	}
+	bStrings := []string{
+		"uOalGMdUBCasdcavsdf",
+		"DIU",
+		"WPTVSN",
+		"CPUVX",
+		"DHndqvCnFX",
+		"XFEAWCPEPGOCCSF",
+		"",
+		"",
+		"b",
+		"a",
+		"A",
+	}
+	expected := []bool{false, true, true, false, false, true, true, true, false, false, true}
+	count := len(aStrings)
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf(
+			"Test case #%d: string a = \"%s\", string b = \"%s\"",
+			i+1,
+			aStrings[i],
+			bStrings[i],
+		)
+		t.Run(name, func(t *testing.T) {
+			result := Abbreviation(aStrings[i], bStrings[i])
+			if result != expected[i] {
+				t.Errorf("Expected the %t, got %t", expected[i], result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Abbreviation Problem
Source: [Hackerrank](https://www.hackerrank.com/challenges/abbr/problem)

## Table of Contents
- [Abbreviation Problem](#abbreviation-problem)
  - [Table of Contents](#table-of-contents)
  - [Source Code](#source-code)
  - [Graphs](#graphs)
    - [Flowchart](#flowchart)
    - [Control Flow Graph](#control-flow-graph)
    - [Data Flow Graph](#data-flow-graph)
  - [All-DU-Paths coverage testcases](#all-du-paths-coverage-testcases)
  - [MCC coverage testcases](#mcc-coverage-testcases)
  - [Other testcases](#other-testcases)

## Source Code
![carbon](https://user-images.githubusercontent.com/25078596/168807342-a60fe302-a2bd-427e-aa85-2c633487fb2f.png)

## Graphs
### Flowchart
![flowchart](https://user-images.githubusercontent.com/25078596/168763419-ce256e24-9b68-410f-8e44-ea95bdf0c613.png)
### Control Flow Graph
![controlflow](https://user-images.githubusercontent.com/25078596/168763432-316cb706-369a-4760-accf-9c0d84b0b378.png)
### Data Flow Graph
![dataflow](https://user-images.githubusercontent.com/25078596/168763393-2f0543cf-9d78-4e11-b212-873bb3998e08.png)



## All-DU-Paths coverage testcases
| Path | a | b | Expected | Actual | Verdict |
|---|---|---|---|---|---|
| 1-> 2-6 -> 8 -> 21 | "" | "" | true | true | Pass |
| 1-> 2-6 -> 8 -> 9 -> 10 -> 11 -> 14 -> 15 ... | "a" | "" | true | true | Pass |
| 1-> 2-6 -> 8 -> 9 -> 10 -> 11 -> 14 -> 15 ... | "a" | "b" | false | false | Pass |
| 1-> 2-6 -> 8 -> 9 -> 10 -> 11 -> 12 -> 14 ... | "a" | "a" | false | false | Pass |
| 1-> 2-6 -> 8 -> 9 -> 10 -> 11 -> 12 -> 14 ... | "A" | "A" | true | true | Pass |

## MCC coverage testcases
Line column show the truth value of the condition of corresponding line: F stands for False and T stands for true.

| Path | Line 8 | Line 9 | Line 10 | Line 11 (j < len(b)) | Line 11 (other one) | Line 14 |  a | b | Expected | Actual | Verdict |
|---|---|---|---|---|---|---|---|---|---|---|---|
| 1 -> 2-7 -> 8 -> 20-22 | F | unknown | unknown | unknown | unknown | unknown | "" | "" | true | true | Pass |
| 1 -> 2-7 -> 8 -> 9 -> 10 -> 11 -> 14 ... | T | T | T | F | unknown | unknown | "a" | "" | true | true | Pass |
| 1 -> 2-7 -> 8 -> 9 -> 10 -> 11 -> 14 ... | F | T | T | T | F | unknown | "a" | "a" | false | false | Pass |
| 1 -> 2-7 -> 8 -> 9 -> 10 -> 11 -> 14 ... | F | T | T | T | F | unknown | "a" | "b" | false | false | Pass |
| 1 -> 2-7 -> 8 -> 9 -> 10 -> 11 -> 12 ... | F | T | T | T | T | T | "A" | "A" | true | true | Pass |

## Other testcases
| a | b | Expected | Actual | Verdict |
|---|---|---|---|---|
| "uOHlGMdUBc" | "uOalGMdUBCasdcavsdf" | false | false | pass |
| "kotgDIUagj" | "DIU" | true | true | pass |
| "WPTffVkSNl" | "WPTVSN" | true | true | pass |
| "CoJsPURrVX" | "CPUVX" | false | false | pass |
| "xasreDHndqvCnFfX" | "DHndqvCnFX" | false | false | pass |
| "XFEaWCxpeepGjOnCCsFh" | "XFEAWCPEPGOCCSF" | true | true | pass |
