### PR TITLE
bump: go 1.19 and fix: fmt issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  go: 1.18
+  go: 1.19
 linters:
   disable:
     - gosimple

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/TheAlgorithms/Go
 
-go 1.18
+go 1.19

--- a/graph/articulationpoints.go
+++ b/graph/articulationpoints.go
@@ -50,7 +50,7 @@ func ArticulationPoint(graph *Graph) []bool {
 // articulationPointHelper is a recursive function to traverse the graph
 // and mark articulation points. Based on the depth first search transversal
 // of the graph, however modified to keep track and update the
-// `child_cnt`, `discovery_time`` and `earliest_discovery` slices defined above
+// `child_cnt`, `discovery_time“ and `earliest_discovery` slices defined above
 func articulationPointHelper(
 	apHelperInstance *apHelper,
 	vertex int,

--- a/graph/articulationpoints.go
+++ b/graph/articulationpoints.go
@@ -50,7 +50,7 @@ func ArticulationPoint(graph *Graph) []bool {
 // articulationPointHelper is a recursive function to traverse the graph
 // and mark articulation points. Based on the depth first search transversal
 // of the graph, however modified to keep track and update the
-// `child_cnt`, `discovery_time“ and `earliest_discovery` slices defined above
+// `child_cnt`, `discovery_time` and `earliest_discovery` slices defined above
 func articulationPointHelper(
 	apHelperInstance *apHelper,
 	vertex int,

--- a/graph/floydwarshall_test.go
+++ b/graph/floydwarshall_test.go
@@ -7,13 +7,13 @@ import (
 
 const float64EqualityThreshold = 1e-9
 
-//almostEqual subtracts two float64 variables and returns true if they differ less then float64EqualityThreshold
-//reference: https://stackoverflow.com/a/47969546
+// almostEqual subtracts two float64 variables and returns true if they differ less then float64EqualityThreshold
+// reference: https://stackoverflow.com/a/47969546
 func almostEqual(a, b float64) bool {
 	return math.Abs(a-b) <= float64EqualityThreshold
 }
 
-//IsAlmostEqualTo verifies if two WeightedGraphs can be considered almost equal
+// IsAlmostEqualTo verifies if two WeightedGraphs can be considered almost equal
 func (a *WeightedGraph) IsAlmostEqualTo(b WeightedGraph) bool {
 	if len(*a) != len(b) {
 		return false

--- a/math/binary/checkisnumberpoweroftwo.go
+++ b/math/binary/checkisnumberpoweroftwo.go
@@ -11,9 +11,11 @@ package binary
 // like 10...0 in binary, and numbers one less than the power of 2
 // are represented like 11...1.
 // Therefore, using the and function:
-//    10...0
-//  & 01...1
-//    00...0 -> 0
+//
+//	  10...0
+//	& 01...1
+//	  00...0 -> 0
+//
 // This is also true for 0, which is not a power of 2, for which we
 // have to add and extra condition.
 func IsPowerOfTwo(x int) bool {

--- a/math/pythagoras/pythagoras.go
+++ b/math/pythagoras/pythagoras.go
@@ -4,14 +4,14 @@ import (
 	"math"
 )
 
-//Vector defines a tuple with 3 values in 3d-space
+// Vector defines a tuple with 3 values in 3d-space
 type Vector struct {
 	x float64
 	y float64
 	z float64
 }
 
-//Distance calculates the distance between to vectors with the   Pythagoras theorem
+// Distance calculates the distance between to vectors with the   Pythagoras theorem
 func Distance(a, b Vector) float64 {
 	res := math.Pow(b.x-a.x, 2.0) + math.Pow(b.y-a.y, 2.0) + math.Pow(b.z-a.z, 2.0)
 	return math.Sqrt(res)

--- a/math/pythagoras/pythagoras_test.go
+++ b/math/pythagoras/pythagoras_test.go
@@ -18,7 +18,7 @@ var distanceTest = []struct {
 	{"random short vectors", Vector{1, 1, 1}, Vector{2, 2, 2}, 1.73},
 }
 
-//TestDistance tests the Function Distance with 2 vectors
+// TestDistance tests the Function Distance with 2 vectors
 func TestDistance(t *testing.T) {
 	t.Parallel() // marks TestDistance as capable of running in parallel with other tests
 	for _, tt := range distanceTest {

--- a/other/nested/nestedbrackets.go
+++ b/other/nested/nestedbrackets.go
@@ -8,9 +8,9 @@ package nested
 //
 // A sequence of brackets `s` is considered properly nested
 // if any of the following conditions are true:
-// 	- `s` is empty;
-// 	- `s` has the form (U) or [U] or {U} where U is a properly nested string;
-// 	- `s` has the form VW where V and W are properly nested strings.
+//   - `s` is empty;
+//   - `s` has the form (U) or [U] or {U} where U is a properly nested string;
+//   - `s` has the form VW where V and W are properly nested strings.
 //
 // For example, the string "()()[()]" is properly nested but "[(()]" is not.
 //

--- a/search/binary.go
+++ b/search/binary.go
@@ -37,8 +37,8 @@ func BinaryIterative(array []int, target int) (int, error) {
 	return -1, ErrNotFound
 }
 
-//Returns index to the first element in the range [0, len(array)-1] that is not less than (i.e. greater or equal to) target.
-//return -1 and ErrNotFound if no such element is found.
+// Returns index to the first element in the range [0, len(array)-1] that is not less than (i.e. greater or equal to) target.
+// return -1 and ErrNotFound if no such element is found.
 func LowerBound(array []int, target int) (int, error) {
 	startIndex := 0
 	endIndex := len(array) - 1
@@ -59,8 +59,8 @@ func LowerBound(array []int, target int) (int, error) {
 	return startIndex, nil
 }
 
-//Returns index to the first element in the range [lowIndex, len(array)-1] that is greater than target.
-//return -1 and ErrNotFound if no such element is found.
+// Returns index to the first element in the range [lowIndex, len(array)-1] that is greater than target.
+// return -1 and ErrNotFound if no such element is found.
 func UpperBound(array []int, target int) (int, error) {
 	startIndex := 0
 	endIndex := len(array) - 1

--- a/search/interpolation.go
+++ b/search/interpolation.go
@@ -4,11 +4,14 @@ package search
 // if the entity is present, it will return the index of the entity, if not -1 will be returned.
 // see: https://en.wikipedia.org/wiki/Interpolation_search
 // Complexity
-// 		Worst: O(N)
-// 		Average: O(log(log(N))  if the elements are uniformly distributed
-// 		Best: O(1)
+//
+//	Worst: O(N)
+//	Average: O(log(log(N))  if the elements are uniformly distributed
+//	Best: O(1)
+//
 // Example
-// 		fmt.Println(InterpolationSearch([]int{1, 2, 9, 20, 31, 45, 63, 70, 100},100))
+//
+//	fmt.Println(InterpolationSearch([]int{1, 2, 9, 20, 31, 45, 63, 70, 100},100))
 func Interpolation(sortedData []int, guess int) (int, error) {
 	if len(sortedData) == 0 {
 		return -1, ErrNotFound

--- a/structure/segmenttree/segmenttree.go
+++ b/structure/segmenttree/segmenttree.go
@@ -13,14 +13,14 @@ import (
 
 const emptyLazyNode = 0
 
-//SegmentTree with original Array and the Segment Tree Array
+// SegmentTree with original Array and the Segment Tree Array
 type SegmentTree struct {
 	Array       []int
 	SegmentTree []int
 	LazyTree    []int
 }
 
-//Propagate lazy tree node values
+// Propagate lazy tree node values
 func (s *SegmentTree) Propagate(node int, leftNode int, rightNode int) {
 	if s.LazyTree[node] != emptyLazyNode {
 		//add lazy node value multiplied by (right-left+1), which represents all interval
@@ -42,8 +42,8 @@ func (s *SegmentTree) Propagate(node int, leftNode int, rightNode int) {
 	}
 }
 
-//Query on interval [firstIndex, leftIndex]
-//node, leftNode and rightNode always should start with 1, 0 and len(Array)-1
+// Query on interval [firstIndex, leftIndex]
+// node, leftNode and rightNode always should start with 1, 0 and len(Array)-1
 func (s *SegmentTree) Query(node int, leftNode int, rightNode int, firstIndex int, lastIndex int) int {
 	if (firstIndex > lastIndex) || (leftNode > rightNode) {
 		//outside the interval
@@ -67,10 +67,10 @@ func (s *SegmentTree) Query(node int, leftNode int, rightNode int, firstIndex in
 	return leftNodeSum + rightNodeSum
 }
 
-//Update Segment Tree
-//node, leftNode and rightNode always should start with 1, 0 and len(Array)-1
-//index is the Array index that you want to update
-//value is the value that you want to override
+// Update Segment Tree
+// node, leftNode and rightNode always should start with 1, 0 and len(Array)-1
+// index is the Array index that you want to update
+// value is the value that you want to override
 func (s *SegmentTree) Update(node int, leftNode int, rightNode int, firstIndex int, lastIndex int, value int) {
 	//propagate lazy tree
 	s.Propagate(node, leftNode, rightNode)
@@ -96,8 +96,8 @@ func (s *SegmentTree) Update(node int, leftNode int, rightNode int, firstIndex i
 	}
 }
 
-//Build Segment Tree
-//node, leftNode and rightNode always should start with 1, 0 and len(Array)-1
+// Build Segment Tree
+// node, leftNode and rightNode always should start with 1, 0 and len(Array)-1
 func (s *SegmentTree) Build(node int, left int, right int) {
 	if left == right {
 		//leaf node

--- a/structure/segmenttree/segmenttree_test.go
+++ b/structure/segmenttree/segmenttree_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-//Query interval
+// Query interval
 type query struct {
 	firstIndex int
 	lastIndex  int

--- a/structure/stack/stacklinkedlistwithlist.go
+++ b/structure/stack/stacklinkedlistwithlist.go
@@ -34,7 +34,7 @@ func (sl *SList) Peak() (any, error) {
 }
 
 // Pop is return last value that insert into our stack
-//also it will remove it in our stack
+// also it will remove it in our stack
 func (sl *SList) Pop() (any, error) {
 	if !sl.Empty() {
 		// get last element that insert into stack


### PR DESCRIPTION
This was done automatically with `go1.19 fmt ./...` to see whether the golangci-lint tool is compatible with the gofmt changes.