### PR TITLE
feat: re-enable all linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,2 @@
 run:
   go: 1.19
-linters:
-  disable:
-    - gosimple
-    - staticcheck
-    - structcheck
-    - unused

--- a/README.md
+++ b/README.md
@@ -876,7 +876,7 @@ Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 
 ---
 
-#####  Package sort Patience sorting is a sorting algorithm inspired by the card game patience.  For more details check out those links below here: GeeksForGeeks article : https://www.geeksforgeeks.org/patience-sorting/ Wikipedia article: https://en.wikipedia.org/wiki/Patience_sorting authors [guuzaa](https://github.com/guuzaa) see patiencesort.go Package sort a package for demonstrating sorting algorithms in Go
+#####  Package sort a package for demonstrating sorting algorithms in Go
 
 ---
 ##### Functions:

--- a/README.md
+++ b/README.md
@@ -548,15 +548,20 @@ Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 ##### Functions:
 
 1. [`Abs`](./math/abs.go#L11):  Abs returns absolute value
-2. [`Cos`](./math/cos.go#L10):  Cos  returns the cosine of the radian argument x. [See more](https://en.wikipedia.org/wiki/Sine_and_cosine) [Based on the idea of Bhaskara approximation of cos(x)](https://math.stackexchange.com/questions/3886552/bhaskara-approximation-of-cosx)
-3. [`FindKthMax`](./math/kthnumber.go#L11):  FindKthMax returns the kth large element given an integer slice with nil `error` if found and returns -1 with `error` `search.ErrNotFound` if not found. NOTE: The `nums` slice gets mutated in the process.
-4. [`FindKthMin`](./math/kthnumber.go#L19):  FindKthMin returns kth small element given an integer slice with nil `error` if found and returns -1 with `error` `search.ErrNotFound` if not found. NOTE: The `nums` slice gets mutated in the process.
-5. [`IsPowOfTwoUseLog`](./math/checkisnumberpoweroftwo.go#L10):  IsPowOfTwoUseLog This function checks if a number is a power of two using the logarithm. The limiting degree can be from 0 to 63. See alternatives in the binary package.
-6. [`Mean`](./math/mean.go#L7): No description provided.
-7. [`Median`](./math/median.go#L12): No description provided.
-8. [`Mode`](./math/mode.go#L19): No description provided.
-9. [`Phi`](./math/eulertotient.go#L5):  Phi is the Euler totient function. This function computes the number of numbers less then n that are coprime with n.
-10. [`Sin`](./math/sin.go#L9):  Sin returns the sine of the radian argument x. [See more](https://en.wikipedia.org/wiki/Sine_and_cosine)
+2. [`Combinations`](./math/binomialcoefficient.go#L20):  C is Binomial Coefficient function This function returns C(n, k) for given n and k
+3. [`Cos`](./math/cos.go#L10):  Cos  returns the cosine of the radian argument x. [See more](https://en.wikipedia.org/wiki/Sine_and_cosine) [Based on the idea of Bhaskara approximation of cos(x)](https://math.stackexchange.com/questions/3886552/bhaskara-approximation-of-cosx)
+4. [`DefaultPolynomial`](./math/pollard.go#L16):  DefaultPolynomial is the commonly used polynomial g(x) = (x^2 + 1) mod n
+5. [`FindKthMax`](./math/kthnumber.go#L11):  FindKthMax returns the kth large element given an integer slice with nil `error` if found and returns -1 with `error` `search.ErrNotFound` if not found. NOTE: The `nums` slice gets mutated in the process.
+6. [`FindKthMin`](./math/kthnumber.go#L19):  FindKthMin returns kth small element given an integer slice with nil `error` if found and returns -1 with `error` `search.ErrNotFound` if not found. NOTE: The `nums` slice gets mutated in the process.
+7. [`IsPowOfTwoUseLog`](./math/checkisnumberpoweroftwo.go#L10):  IsPowOfTwoUseLog This function checks if a number is a power of two using the logarithm. The limiting degree can be from 0 to 63. See alternatives in the binary package.
+8. [`LiouvilleLambda`](./math/liouville.go#L24):  Lambda is the liouville function This function returns λ(n) for given number
+9. [`Mean`](./math/mean.go#L7): No description provided.
+10. [`Median`](./math/median.go#L12): No description provided.
+11. [`Mode`](./math/mode.go#L19): No description provided.
+12. [`Mu`](./math/mobius.go#L21):  Mu is the Mobius function This function returns μ(n) for given number
+13. [`Phi`](./math/eulertotient.go#L5):  Phi is the Euler totient function. This function computes the number of numbers less then n that are coprime with n.
+14. [`PollardsRhoFactorization`](./math/pollard.go#L29):  PollardsRhoFactorization is an implementation of Pollard's rho factorization algorithm using the default parameters x = y = 2
+15. [`Sin`](./math/sin.go#L9):  Sin returns the sine of the radian argument x. [See more](https://en.wikipedia.org/wiki/Sine_and_cosine)
 
 ---
 </details><details>

--- a/math/mode.go
+++ b/math/mode.go
@@ -27,11 +27,7 @@ func Mode[T constraints.Number](numbers []T) (T, error) {
 	}
 
 	for _, number := range numbers {
-		if _, check := countMap[number]; check {
-			countMap[number]++
-		} else {
-			countMap[number] = 1
-		}
+		countMap[number]++
 	}
 
 	var mode T

--- a/sort/patiencesort.go
+++ b/sort/patiencesort.go
@@ -1,4 +1,3 @@
-// Package sort
 // Patience sorting is a sorting algorithm inspired by the card game patience.
 //
 // For more details check out those links below here:
@@ -6,6 +5,7 @@
 // Wikipedia article: https://en.wikipedia.org/wiki/Patience_sorting
 // authors [guuzaa](https://github.com/guuzaa)
 // see patiencesort.go
+
 package sort
 
 import "github.com/TheAlgorithms/Go/constraints"


### PR DESCRIPTION
This re-enables all the golanci-lint linters and checks that are on by default.

Closes #510