### PR TITLE
feat: Add fuzzing for cipher/xor

### DIFF
--- a/cipher/xor/xor_test.go
+++ b/cipher/xor/xor_test.go
@@ -1,6 +1,7 @@
 package xor
 
 import (
+	"bytes"
 	"fmt"
 	"reflect"
 	"testing"
@@ -102,4 +103,15 @@ func TestXorCipherDecrypt(t *testing.T) {
 			}
 		})
 	}
+}
+
+func FuzzXOR(f *testing.F) {
+	f.Add([]byte("The Quick Brown Fox Jumps over the Lazy Dog."), byte('X'))
+	f.Fuzz(func(t *testing.T, input []byte, key byte) {
+		cipherText := Encrypt(key, input)
+		result := Decrypt(key, cipherText)
+		if !bytes.Equal(input, result) {
+			t.Errorf("Before: %s, after: %s, key: %d", input, result, key)
+		}
+	})
 }


### PR DESCRIPTION
Following up from #480, adding fuzzing test to cipher/xor function.

I ran `go test -fuzz=Fuzz -fuzztime 30s cipher/xor/*.go` and got the output below:
```
fuzz: elapsed: 0s, gathering baseline coverage: 0/8 completed
fuzz: elapsed: 0s, gathering baseline coverage: 8/8 completed, now fuzzing with 10 workers
fuzz: elapsed: 3s, execs: 1541453 (513640/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 6s, execs: 3078539 (512364/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 9s, execs: 4648655 (523545/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 12s, execs: 6233252 (528124/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 15s, execs: 7810894 (525865/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 18s, execs: 9394482 (527848/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 21s, execs: 10964800 (523534/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 24s, execs: 12536121 (523682/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 27s, execs: 14119233 (527786/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 30s, execs: 15706281 (529005/sec), new interesting: 0 (total: 8)
fuzz: elapsed: 30s, execs: 15706281 (0/sec), new interesting: 0 (total: 8)
PASS
ok      command-line-arguments  30.481s
```