### PR TITLE
feat(cipher/caesar): add fuzzy test to caesar cipher

### DIFF
--- a/cipher/caesar/caesar.go
+++ b/cipher/caesar/caesar.go
@@ -9,12 +9,12 @@ func Encrypt(input string, key int) string {
 	key8 := byte(key%26+26) % 26
 
 	var outputBuffer []byte
-	// r is a rune, which is the equivalent of uint32.
-	for _, r := range input {
-		newByte := byte(r)
-		if 'A' <= r && r <= 'Z' {
+	// b is a byte, which is the equivalent of uint8.
+	for _, b := range []byte(input) {
+		newByte := b
+		if 'A' <= b && b <= 'Z' {
 			outputBuffer = append(outputBuffer, 'A'+(newByte-'A'+key8)%26)
-		} else if 'a' <= r && r <= 'z' {
+		} else if 'a' <= b && b <= 'z' {
 			outputBuffer = append(outputBuffer, 'a'+(newByte-'a'+key8)%26)
 		} else {
 			outputBuffer = append(outputBuffer, newByte)

--- a/cipher/caesar/caesar_test.go
+++ b/cipher/caesar/caesar_test.go
@@ -2,7 +2,9 @@ package caesar
 
 import (
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 )
 
 func TestEncrypt(t *testing.T) {
@@ -151,4 +153,15 @@ func Example() {
 	// Output:
 	// Encrypt=> key: 10, input: The Quick Brown Fox Jumps over the Lazy Dog., encryptedText: Dro Aesmu Lbygx Pyh Tewzc yfob dro Vkji Nyq.
 	// Decrypt=> key: 10, input: Dro Aesmu Lbygx Pyh Tewzc yfob dro Vkji Nyq., decryptedText: The Quick Brown Fox Jumps over the Lazy Dog.
+}
+
+func FuzzCaesar(f *testing.F) {
+	rand.Seed(time.Now().Unix())
+	f.Add("The Quick Brown Fox Jumps over the Lazy Dog.")
+	f.Fuzz(func(t *testing.T, input string) {
+		key := rand.Intn(26)
+		if result := Decrypt(Encrypt(input, key), key); result != input {
+			t.Fatalf("With input: '%s' and key: %d\n\tExpected: '%s'\n\tGot: '%s'", input, key, input, result)
+		}
+	})
 }


### PR DESCRIPTION
Added Fuzzy test to Caesar Cipher

I had to make a small change in the algorithm approach and treat the input text as a byte array, as the old way some characters were converted wrong. An example obtained when running fuzzy was the character `ǃ` (note that this is different from `!`) was converted to `�` and not returned to normal in `Decrypt`.

![image](https://user-images.githubusercontent.com/23376064/194723899-69686b93-b0f3-4f84-bdcf-a672a64818f8.png)
In this image you can better see the difference between the two characters (left: the one responsible for the problem; right: the normal character)


I don't know if I chose the best approach. I'm willing to change that and also give more details about the problem.

Ref https://github.com/TheAlgorithms/Go/issues/480