### PR TITLE
refactor: simplity signature of `LongestCommonSubsequence`

### DIFF
--- a/dynamic/longestcommonsubsequence.go
+++ b/dynamic/longestcommonsubsequence.go
@@ -10,18 +10,18 @@ import (
 
 // LongestCommonSubsequence function
 func LongestCommonSubsequence(a string, b string) int {
-	var a_len = utf8.RuneCountInString(a)
-	var b_len = utf8.RuneCountInString(b)
+	var aLen = utf8.RuneCountInString(a)
+	var bLen = utf8.RuneCountInString(b)
 
-	// here we are making a 2d slice of size (a_len+1)*(b_len+1)
-	lcs := make([][]int, a_len+1)
-	for i := 0; i <= a_len; i++ {
-		lcs[i] = make([]int, b_len+1)
+	// here we are making a 2d slice of size (aLen+1)*(bLen+1)
+	lcs := make([][]int, aLen+1)
+	for i := 0; i <= aLen; i++ {
+		lcs[i] = make([]int, bLen+1)
 	}
 
 	// block that implements LCS
-	for i := 0; i <= a_len; i++ {
-		for j := 0; j <= b_len; j++ {
+	for i := 0; i <= aLen; i++ {
+		for j := 0; j <= bLen; j++ {
 			if i == 0 || j == 0 {
 				lcs[i][j] = 0
 			} else if a[i-1] == b[j-1] {
@@ -32,7 +32,7 @@ func LongestCommonSubsequence(a string, b string) int {
 		}
 	}
 	// returning the length of longest common subsequence
-	return lcs[a_len][b_len]
+	return lcs[aLen][bLen]
 }
 
 // func main(){

--- a/dynamic/longestcommonsubsequence.go
+++ b/dynamic/longestcommonsubsequence.go
@@ -4,19 +4,24 @@
 
 package dynamic
 
-// LongestCommonSubsequence function
-func LongestCommonSubsequence(a string, b string, m int, n int) int {
-	// m is the length of string a and n is the length of string b
+import (
+	"unicode/utf8"
+)
 
-	// here we are making a 2d slice of size (m+1)*(n+1)
-	lcs := make([][]int, m+1)
-	for i := 0; i <= m; i++ {
-		lcs[i] = make([]int, n+1)
+// LongestCommonSubsequence function
+func LongestCommonSubsequence(a string, b string) int {
+	var a_len = utf8.RuneCountInString(a)
+	var b_len = utf8.RuneCountInString(b)
+
+	// here we are making a 2d slice of size (a_len+1)*(b_len+1)
+	lcs := make([][]int, a_len+1)
+	for i := 0; i <= a_len; i++ {
+		lcs[i] = make([]int, b_len+1)
 	}
 
 	// block that implements LCS
-	for i := 0; i <= m; i++ {
-		for j := 0; j <= n; j++ {
+	for i := 0; i <= a_len; i++ {
+		for j := 0; j <= b_len; j++ {
 			if i == 0 || j == 0 {
 				lcs[i][j] = 0
 			} else if a[i-1] == b[j-1] {
@@ -27,7 +32,7 @@ func LongestCommonSubsequence(a string, b string, m int, n int) int {
 		}
 	}
 	// returning the length of longest common subsequence
-	return lcs[m][n]
+	return lcs[a_len][b_len]
 }
 
 // func main(){
@@ -36,5 +41,5 @@ func LongestCommonSubsequence(a string, b string, m int, n int) int {
 // 	var a,b string
 // 	fmt.Scan(&a, &b)
 // 	// calling the LCS function
-// 	fmt.Println("The length of longest common subsequence is:", longestCommonSubsequence(a,b, len(a), len(b)))
+// 	fmt.Println("The length of longest common subsequence is:", longestCommonSubsequence(a,b))
 // }

--- a/dynamic/longestcommonsubsequence.go
+++ b/dynamic/longestcommonsubsequence.go
@@ -34,12 +34,3 @@ func LongestCommonSubsequence(a string, b string) int {
 	// returning the length of longest common subsequence
 	return lcs[aLen][bLen]
 }
-
-// func main(){
-// 	// declaring two strings and asking for input
-
-// 	var a,b string
-// 	fmt.Scan(&a, &b)
-// 	// calling the LCS function
-// 	fmt.Println("The length of longest common subsequence is:", longestCommonSubsequence(a,b))
-// }

--- a/dynamic/longestcommonsubsequence_test.go
+++ b/dynamic/longestcommonsubsequence_test.go
@@ -27,15 +27,14 @@ func getLCSTestCases() []testCaseLCS {
 		{"abcdef", "aXbXcXXXdeXXf", 6},
 		{"", "abc", 0},
 		{"", "", 0},
+		{"££", "££", 2},
 	}
 }
 
 func TestLongestCommonSubsequence(t *testing.T) {
 	t.Run("Simple test", func(t *testing.T) {
 		for _, tc := range getLCSTestCases() {
-			actual := dynamic.LongestCommonSubsequence(
-				tc.stringA, tc.stringB,
-				len(tc.stringA), len(tc.stringB))
+			actual := dynamic.LongestCommonSubsequence(tc.stringA, tc.stringB)
 			if actual != tc.expected {
 				t.Errorf("expected: %d, but got: %d", tc.expected, actual)
 			}
@@ -44,9 +43,7 @@ func TestLongestCommonSubsequence(t *testing.T) {
 
 	t.Run("Symmetry test", func(t *testing.T) {
 		for _, tc := range getLCSTestCases() {
-			actual := dynamic.LongestCommonSubsequence(
-				tc.stringB, tc.stringA,
-				len(tc.stringB), len(tc.stringA))
+			actual := dynamic.LongestCommonSubsequence(tc.stringB, tc.stringA)
 			if actual != tc.expected {
 				t.Errorf("expected: %d, but got: %d", tc.expected, actual)
 			}


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/Go/CONTRIBUTING.md
-->
In this PR I remove the _length of the strings_ arguments in `LongestCommonSubsequence`, update the relevant tests and add a test case, which justifies the usage of `utf8.RuneCountInString` instead of `len`.

I think that having the length of the input strings in `LongestCommonSubsequence` is a bit redundant. Also by looking at implementations in other languages like:
- [python](https://github.com/TheAlgorithms/Python/blob/6118b05f0efd1c2839eb8bc4de36723af1fcc364/dynamic_programming/longest_common_subsequence.py#L9),
- [rust](https://github.com/TheAlgorithms/Rust/blob/5bb80cdfbe8092cfaf111f06a8abe9f205849856/src/dynamic_programming/longest_common_subsequence.rs#L5),
- [java](https://github.com/TheAlgorithms/Java/blob/c805437c0c5e057f3ad60c397fe6550eec7be453/src/main/java/com/thealgorithms/dynamicprogramming/LongestCommonSubsequence.java#L5),

I am convinced that this is a good direction.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/Go/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
This PR shortens the argument list of the function `LongestCommonSubsequence`.