### PR TITLE
refactor: fmt.Printf in strings/kmp

### DIFF
--- a/strings/kmp/kmp.go
+++ b/strings/kmp/kmp.go
@@ -71,10 +71,11 @@ func Kmp(text string, word string) Result {
 	m, i, c := 0, 0, 0
 	t := kmpTable(word)
 	for m+i < len(text) {
-		fmt.Printf("\n   comparing characters %c %c at positions %d %d", text[m+i], word[i], m+i, i)
+		message := fmt.Sprintf("\tcomparing characters %c %c at positions %d %d", text[m+i], word[i], m+i, i)
+
 		c++
 		if word[i] == text[m+i] {
-			fmt.Printf(" - match")
+			fmt.Printf("%s - match\n", message)
 			if i == len(word)-1 {
 				return Result{
 					m, c,
@@ -82,6 +83,7 @@ func Kmp(text string, word string) Result {
 			}
 			i++
 		} else {
+			fmt.Printf("%s\n", message)
 			m = m + i - t[i]
 			if t[i] > -1 {
 				i = t[i]


### PR DESCRIPTION
## Description
Hi!
This is my first pull request to this repository!

Refactored `fmt.Printf` so that it is done in each block, and do not insert a newline code at the beginning of `fmt.Printf`.

I'll also include the output below.

```
go test -v
=== RUN   TestKMP
=== RUN   TestKMP/String_comparison_on_single_pattern_match
        comparing characters C a at positions 0 0
        comparing characters P a at positions 1 0
        comparing characters M a at positions 2 0
        comparing characters _ a at positions 3 0
        comparing characters a a at positions 4 0 - match
        comparing characters n n at positions 5 1 - match
        comparing characters n n at positions 6 2 - match
        comparing characters u o at positions 7 3
        comparing characters u a at positions 7 0
        comparing characters a a at positions 8 0 - match
        comparing characters l n at positions 9 1
        comparing characters l a at positions 9 0
        comparing characters _ a at positions 10 0
        comparing characters c a at positions 11 0
        comparing characters o a at positions 12 0
        comparing characters n a at positions 13 0
        comparing characters f a at positions 14 0
        comparing characters e a at positions 15 0
        comparing characters r a at positions 16 0
        comparing characters e a at positions 17 0
        comparing characters n a at positions 18 0
        comparing characters c a at positions 19 0
        comparing characters e a at positions 20 0
        comparing characters _ a at positions 21 0
        comparing characters a a at positions 22 0 - match
        comparing characters n n at positions 23 1 - match
        comparing characters n n at positions 24 2 - match
        comparing characters o o at positions 25 3 - match
        comparing characters u u at positions 26 4 - match
        comparing characters n n at positions 27 5 - match
        comparing characters c c at positions 28 6 - match
        comparing characters e e at positions 29 7 - match
=== RUN   TestKMP/String_comparison_on_multiple_pattern_match
        comparing characters A A at positions 0 0 - match
        comparing characters A A at positions 1 1 - match
        comparing characters B B at positions 2 2 - match
        comparing characters A A at positions 3 3 - match
=== RUN   TestKMP/String_comparison_with_not_found_pattern
        comparing characters A A at positions 0 0 - match
        comparing characters A A at positions 1 1 - match
        comparing characters B B at positions 2 2 - match
        comparing characters A C at positions 3 3
        comparing characters A A at positions 3 0 - match
        comparing characters A A at positions 4 1 - match
        comparing characters C B at positions 5 2
        comparing characters C A at positions 5 1
        comparing characters C A at positions 5 0
        comparing characters A A at positions 6 0 - match
        comparing characters A A at positions 7 1 - match
        comparing characters D B at positions 8 2
        comparing characters D A at positions 8 1
        comparing characters D A at positions 8 0
        comparing characters A A at positions 9 0 - match
        comparing characters A A at positions 10 1 - match
        comparing characters B B at positions 11 2 - match
        comparing characters A C at positions 12 3
        comparing characters A A at positions 12 0 - match
        comparing characters A A at positions 13 1 - match
        comparing characters B B at positions 14 2 - match
        comparing characters A C at positions 15 3
        comparing characters A A at positions 15 0 - match
--- PASS: TestKMP (0.00s)
    --- PASS: TestKMP/String_comparison_on_single_pattern_match (0.00s)
    --- PASS: TestKMP/String_comparison_on_multiple_pattern_match (0.00s)
    --- PASS: TestKMP/String_comparison_with_not_found_pattern (0.00s)
```

Checklist
- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/Go/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
 - [x] I acknowledge that all my contributions will be made under the project's license.