### PR TITLE
feat(cipher/polybius): add fuzz test to polybius cipher

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 7. [`EditDistanceRecursive`](./dynamic/editdistance.go#L10):  EditDistanceRecursive is a naive implementation with exponential time complexity.
 8. [`IsSubsetSum`](./dynamic/subsetsum.go#L14): No description provided.
 9. [`Knapsack`](./dynamic/knapsack.go#L17):  Knapsack solves knapsack problem return maxProfit
-10. [`LongestCommonSubsequence`](./dynamic/longestcommonsubsequence.go#L12):  LongestCommonSubsequence function
+10. [`LongestCommonSubsequence`](./dynamic/longestcommonsubsequence.go#L13):  LongestCommonSubsequence function
 11. [`LongestIncreasingSubsequence`](./dynamic/longestincreasingsubsequence.go#L9):  LongestIncreasingSubsequence returns the longest increasing subsequence where all elements of the subsequence are sorted in increasing order
 12. [`LongestIncreasingSubsequenceGreedy`](./dynamic/longestincreasingsubsequencegreedy.go#L9):  LongestIncreasingSubsequenceGreedy is a function to find the longest increasing subsequence in a given array using a greedy approach. The dynamic programming approach is implemented alongside this one. Worst Case Time Complexity: O(nlogn) Auxiliary Space: O(n), where n is the length of the array(slice). Reference: https://www.geeksforgeeks.org/construction-of-longest-monotonically-increasing-subsequence-n-log-n/
 13. [`LpsDp`](./dynamic/longestpalindromicsubsequence.go#L25):  LpsDp function
@@ -777,6 +777,19 @@ Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 
 3. [`Queue`](./structure/queue/queuelinkedlist.go#L19): No description provided.
 
+
+---
+</details><details>
+	<summary> <strong> rot13 </strong> </summary>	
+
+---
+
+#####  Package rot13 is a simple letter substitution cipher that replaces a letter with the 13th letter after it in the alphabet. ref: https://en.wikipedia.org/wiki/ROT13
+
+---
+##### Functions:
+
+1. [`FuzzRot13`](./cipher/rot13/rot13_test.go#L72): No description provided.
 
 ---
 </details><details>

--- a/cipher/polybius/polybius.go
+++ b/cipher/polybius/polybius.go
@@ -19,11 +19,22 @@ type Polybius struct {
 // If the size of "chars" is longer than "size",
 // "chars" are truncated to "size".
 func NewPolybius(key string, size int, chars string) (*Polybius, error) {
+	if size < 0 {
+		return nil, fmt.Errorf("provided size %d cannot be negative", size)
+	}
 	key = strings.ToUpper(key)
+	if size > len(chars) {
+		return nil, fmt.Errorf("provided size %d is too small to use to slice string %q of len %d", size, chars, len(chars))
+	}
+	for _, r := range chars {
+		if (r < 'a' || r > 'z') && (r < 'A' || r > 'Z') {
+			return nil, fmt.Errorf("provided string %q should only contain latin characters", chars)
+		}
+	}
 	chars = strings.ToUpper(chars)[:size]
-	for idx, ch := range chars {
-		if strings.Contains(chars[idx+1:], string(ch)) {
-			return nil, fmt.Errorf("\"chars\" contains same character: %c", ch)
+	for i, r := range chars {
+		if strings.ContainsRune(chars[i+1:], r) {
+			return nil, fmt.Errorf("%q contains same character %q", chars[i+1:], r)
 		}
 	}
 
@@ -63,7 +74,7 @@ func (p *Polybius) Decrypt(text string) (string, error) {
 func (p *Polybius) encipher(char rune) (string, error) {
 	index := strings.IndexRune(p.key, char)
 	if index < 0 {
-		return "", fmt.Errorf("%c does not exist in keys", char)
+		return "", fmt.Errorf("%q does not exist in keys", char)
 	}
 	row := index / p.size
 	col := index % p.size
@@ -83,5 +94,5 @@ func (p *Polybius) decipher(chars []rune) (string, error) {
 	if col < 0 {
 		return "", fmt.Errorf("%c does not exist in characters", chars[1])
 	}
-	return string([]rune(p.key)[row*p.size+col]), nil
+	return string(p.key[row*p.size+col]), nil
 }


### PR DESCRIPTION
Hi again, I keep adding fuzz tests for #480, this time for Polybius. I tested it with go test ./cipher/polybius/ to test the corpus and go test -fuzz=FuzzPoly ./cipher/polybius/ to run the fuzzer itself.
If that Is that ok for you to add it let me know. Also if you have any feedbacks about my change let me know so that I can adapt it.
You will see that I did some changes to the errors and restrict some more the possible inputs to the algorithm based a bit on the description of the algorithm in the wikipedia page mentioned at the beginning of the polybius file.
Thanks again for your work!