### PR TITLE
feat(cipher/diffiehellman): add fuzz test to key generators in diffiehellman algorithm

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 7. [`EditDistanceRecursive`](./dynamic/editdistance.go#L10):  EditDistanceRecursive is a naive implementation with exponential time complexity.
 8. [`IsSubsetSum`](./dynamic/subsetsum.go#L14): No description provided.
 9. [`Knapsack`](./dynamic/knapsack.go#L17):  Knapsack solves knapsack problem return maxProfit
-10. [`LongestCommonSubsequence`](./dynamic/longestcommonsubsequence.go#L12):  LongestCommonSubsequence function
+10. [`LongestCommonSubsequence`](./dynamic/longestcommonsubsequence.go#L13):  LongestCommonSubsequence function
 11. [`LongestIncreasingSubsequence`](./dynamic/longestincreasingsubsequence.go#L9):  LongestIncreasingSubsequence returns the longest increasing subsequence where all elements of the subsequence are sorted in increasing order
 12. [`LongestIncreasingSubsequenceGreedy`](./dynamic/longestincreasingsubsequencegreedy.go#L9):  LongestIncreasingSubsequenceGreedy is a function to find the longest increasing subsequence in a given array using a greedy approach. The dynamic programming approach is implemented alongside this one. Worst Case Time Complexity: O(nlogn) Auxiliary Space: O(n), where n is the length of the array(slice). Reference: https://www.geeksforgeeks.org/construction-of-longest-monotonically-increasing-subsequence-n-log-n/
 13. [`LpsDp`](./dynamic/longestpalindromicsubsequence.go#L25):  LpsDp function
@@ -777,6 +777,19 @@ Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 
 3. [`Queue`](./structure/queue/queuelinkedlist.go#L19): No description provided.
 
+
+---
+</details><details>
+	<summary> <strong> rot13 </strong> </summary>	
+
+---
+
+#####  Package rot13 is a simple letter substitution cipher that replaces a letter with the 13th letter after it in the alphabet. ref: https://en.wikipedia.org/wiki/ROT13
+
+---
+##### Functions:
+
+1. [`FuzzRot13`](./cipher/rot13/rot13_test.go#L72): No description provided.
 
 ---
 </details><details>

--- a/cipher/diffiehellman/diffiehellmankeyexchange_test.go
+++ b/cipher/diffiehellman/diffiehellmankeyexchange_test.go
@@ -39,3 +39,21 @@ func TestDiffieHellmanKeyExchange(t *testing.T) {
 		}
 	})
 }
+
+func FuzzGenSharedKey(f *testing.F) {
+	f.Add(int64(13))
+	f.Fuzz(func(t *testing.T, prvKey int64) {
+		// explicitly ignoring the return value
+		// here we want to test that no strange behaviors are raised when executing GenerateShareKey
+		_ = GenerateShareKey(prvKey)
+	})
+}
+
+func FuzzGenMutualKey(f *testing.F) {
+	f.Add(int64(5), int64(17))
+	f.Fuzz(func(t *testing.T, prvKey, shrdKey int64) {
+		// explicitly ignoring the return value
+		// here we want to test that no strange behaviors are raised when executing GenerateMutualKey
+		_ = GenerateMutualKey(prvKey, shrdKey)
+	})
+}


### PR DESCRIPTION
Hello, I think this is the last subpackage for the cipher package where the fuzz tests were not yet present. I added two quick fuzz tests for the key generators and tested them with 'go test ./cipher/diffiehellman/ -fuzz=FuzzGenM' and 'go test ./cipher/diffiehellman/ -fuzz=FuzzGenS' to check that the execution was getting along just fine.
Let me know if you have any feedbacks on it. Thanks again!

PR linked to issue #480 