### PR TITLE
Improve Bubblesort comparisons 

### DIFF
--- a/sort/bubblesort.go
+++ b/sort/bubblesort.go
@@ -15,6 +15,7 @@ func Bubble[T constraints.Ordered](arr []T) []T {
 			if arr[i+1] < arr[i] {
 				arr[i+1], arr[i] = arr[i], arr[i+1]
 				swapped = true
+				sortedIdx++
 			}
 		}
 	}

--- a/sort/bubblesort.go
+++ b/sort/bubblesort.go
@@ -8,9 +8,10 @@ import "github.com/TheAlgorithms/Go/constraints"
 // Bubble is a simple generic definition of Bubble sort algorithm.
 func Bubble[T constraints.Ordered](arr []T) []T {
 	swapped := true
+	sortedIdx := 1
 	for swapped {
 		swapped = false
-		for i := 0; i < len(arr)-1; i++ {
+		for i := 0; i < len(arr)-sortedIdx; i++ {
 			if arr[i+1] < arr[i] {
 				arr[i+1], arr[i] = arr[i], arr[i+1]
 				swapped = true


### PR DESCRIPTION
Hi, 

During the Bubble Sort for **N** elements, we make
(N - 1) + (N - 2) + (N - 3) … + 1 comparisons.

*Eg for 5 element array:*
We should have
4 + 3 + 2 + 1 = 10 comparisons.
4 + 3+ 2 + 1 = 10 swaps in the worst cenario.

But with the current implementation we have 
4+4+4+4 = 16 comparisons.