### PR TITLE
test: Add benchmark for prime sieve

### DIFF
--- a/math/prime/sieve_test.go
+++ b/math/prime/sieve_test.go
@@ -44,3 +44,9 @@ func TestGeneratePrimes(t *testing.T) {
 		}
 	})
 }
+
+func BenchmarkSieve10(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = Generate(10)
+	}
+}


### PR DESCRIPTION
I've added a simple benchmark for the prime sieve Generate function, when the input limit is 10. 

