### PR TITLE
chore: update `actions/setup-go` to `v4`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: '^1.18'
       - name: Run Golang CI Lint

--- a/.github/workflows/godocmd.yml
+++ b/.github/workflows/godocmd.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
           go-version: '^1.18'
       - name: Install GoDocMD


### PR DESCRIPTION
This PR updates used `setup-go` action to `v4`.