### PR TITLE
Add Cocktail Sort

### DIFF
--- a/sort/cocktailsort.go
+++ b/sort/cocktailsort.go
@@ -1,0 +1,40 @@
+// Implementation of Cocktail sorting
+// reference: https://en.wikipedia.org/wiki/Cocktail_shaker_sort
+
+package sort
+
+import "github.com/TheAlgorithms/Go/constraints"
+
+func Cocktail[T constraints.Integer](arr []T) []T {
+	if len(arr) == 0 { // guard clause for 0 length arrays
+		return arr
+	}
+
+	swapped := false
+
+	for ok := true; ok; ok = swapped {
+		for i := 0; i < len(arr)-1; i++ { // loop from array's beginning to end
+			if arr[i] > arr[i+1] { // swap unsorted elements
+				arr[i], arr[i+1] = arr[i+1], arr[i]
+				swapped = true
+			}
+		}
+
+		if !swapped {
+			// if swapped == false, first loop didn't find any unsorted elements.
+			// array is sorted
+			break
+		}
+
+		swapped = false
+
+		for i := len(arr) - 1; i > 0; i-- { // loop from array's end to beginning
+			if arr[i] < arr[i-1] { // swap unsorted elements
+				arr[i], arr[i-1] = arr[i-1], arr[i]
+				swapped = true
+			}
+		}
+	}
+
+	return arr
+}

--- a/sort/cocktailsort.go
+++ b/sort/cocktailsort.go
@@ -6,7 +6,7 @@ package sort
 import "github.com/TheAlgorithms/Go/constraints"
 
 // Cocktail sort is a variation of bubble sort, operating in two directions (beginning to end, end to beginning)
-func Cocktail[T constraints.Integer](arr []T) []T {
+func Cocktail[T constraints.Ordered](arr []T) []T {
 	if len(arr) == 0 { // ignore 0 length arrays
 		return arr
 	}

--- a/sort/cocktailsort.go
+++ b/sort/cocktailsort.go
@@ -11,14 +11,14 @@ func Cocktail[T constraints.Integer](arr []T) []T {
 		return arr
 	}
 
-	swapped := false // true if swapped two or more elements in the last loop
+	swapped := true // true if swapped two or more elements in the last loop
 	// if it loops through the array without swapping, the array is sorted
 
 	// start and end indexes, this will be updated excluding already sorted elements
 	start := 0
 	end := len(arr) - 1
 
-	for {
+	for swapped {
 		swapped = false
 		var new_start int
 		var new_end int
@@ -48,10 +48,6 @@ func Cocktail[T constraints.Integer](arr []T) []T {
 		}
 
 		start = new_start
-
-		if !swapped {
-			break
-		}
 	}
 
 	return arr

--- a/sort/cocktailsort.go
+++ b/sort/cocktailsort.go
@@ -5,31 +5,30 @@ package sort
 
 import "github.com/TheAlgorithms/Go/constraints"
 
+// Cocktail sort is a variation of bubble sort, operating in two directions (beginning to end, end to beginning)
 func Cocktail[T constraints.Integer](arr []T) []T {
-	if len(arr) == 0 { // guard clause for 0 length arrays
+	if len(arr) == 0 {
 		return arr
 	}
 
 	swapped := false
 
 	for ok := true; ok; ok = swapped {
-		for i := 0; i < len(arr)-1; i++ { // loop from array's beginning to end
-			if arr[i] > arr[i+1] { // swap unsorted elements
+		for i := 0; i < len(arr)-1; i++ {
+			if arr[i] > arr[i+1] {
 				arr[i], arr[i+1] = arr[i+1], arr[i]
 				swapped = true
 			}
 		}
 
 		if !swapped {
-			// if swapped == false, first loop didn't find any unsorted elements.
-			// array is sorted
 			break
 		}
 
 		swapped = false
 
-		for i := len(arr) - 1; i > 0; i-- { // loop from array's end to beginning
-			if arr[i] < arr[i-1] { // swap unsorted elements
+		for i := len(arr) - 1; i > 0; i-- {
+			if arr[i] < arr[i-1] {
 				arr[i], arr[i-1] = arr[i-1], arr[i]
 				swapped = true
 			}

--- a/sort/cocktailsort.go
+++ b/sort/cocktailsort.go
@@ -7,28 +7,30 @@ import "github.com/TheAlgorithms/Go/constraints"
 
 // Cocktail sort is a variation of bubble sort, operating in two directions (beginning to end, end to beginning)
 func Cocktail[T constraints.Integer](arr []T) []T {
-	if len(arr) == 0 {
+	if len(arr) == 0 { // ignore 0 length arrays
 		return arr
 	}
 
-	swapped := false
+	swapped := false // true if swapped two or more elements in the last loop
+	// if it loops through the array without swapping, the array is sorted
 
-	for ok := true; ok; ok = swapped {
-		for i := 0; i < len(arr)-1; i++ {
-			if arr[i] > arr[i+1] {
-				arr[i], arr[i+1] = arr[i+1], arr[i]
+	for ok := true; ok; ok = swapped { // exits when swapped == false
+
+		for i := 0; i < len(arr)-1; i++ { // first loop, from array's beginning to end
+			if arr[i] > arr[i+1] { // if current and next elements are unordered
+				arr[i], arr[i+1] = arr[i+1], arr[i] // swap two elements
 				swapped = true
 			}
 		}
 
-		if !swapped {
+		if !swapped { // early exit, skipping the second loop
 			break
 		}
 
 		swapped = false
 
-		for i := len(arr) - 1; i > 0; i-- {
-			if arr[i] < arr[i-1] {
+		for i := len(arr) - 1; i > 0; i-- { // second loop, from array's end to beginning
+			if arr[i] < arr[i-1] { // same process of the first loop, now going 'backwards'
 				arr[i], arr[i-1] = arr[i-1], arr[i]
 				swapped = true
 			}

--- a/sort/cocktailsort.go
+++ b/sort/cocktailsort.go
@@ -14,14 +14,24 @@ func Cocktail[T constraints.Integer](arr []T) []T {
 	swapped := false // true if swapped two or more elements in the last loop
 	// if it loops through the array without swapping, the array is sorted
 
-	for ok := true; ok; ok = swapped { // exits when swapped == false
+	// start and end indexes, this will be updated excluding already sorted elements
+	start := 0
+	end := len(arr) - 1
 
-		for i := 0; i < len(arr)-1; i++ { // first loop, from array's beginning to end
+	for {
+		swapped = false
+		var new_start int
+		var new_end int
+
+		for i := start; i < end; i++ { // first loop, from start to end
 			if arr[i] > arr[i+1] { // if current and next elements are unordered
 				arr[i], arr[i+1] = arr[i+1], arr[i] // swap two elements
+				new_end = i
 				swapped = true
 			}
 		}
+
+		end = new_end
 
 		if !swapped { // early exit, skipping the second loop
 			break
@@ -29,11 +39,18 @@ func Cocktail[T constraints.Integer](arr []T) []T {
 
 		swapped = false
 
-		for i := len(arr) - 1; i > 0; i-- { // second loop, from array's end to beginning
+		for i := end; i > start; i-- { // second loop, from end to start
 			if arr[i] < arr[i-1] { // same process of the first loop, now going 'backwards'
 				arr[i], arr[i-1] = arr[i-1], arr[i]
+				new_start = i
 				swapped = true
 			}
+		}
+
+		start = new_start
+
+		if !swapped {
+			break
 		}
 	}
 

--- a/sort/sorts_test.go
+++ b/sort/sorts_test.go
@@ -227,6 +227,10 @@ func BenchmarkBucketSort(b *testing.B) {
 	benchmarkFramework(b, sort.Bucket[int])
 }
 
+func BenchmarkCocktailSort(b *testing.B) {
+	benchmarkFramework(b, sort.Cocktail[int])
+}
+
 func BenchmarkExchange(b *testing.B) {
 	benchmarkFramework(b, sort.Exchange[int])
 }

--- a/sort/sorts_test.go
+++ b/sort/sorts_test.go
@@ -1,11 +1,12 @@
 package sort_test
 
 import (
-	"github.com/TheAlgorithms/Go/sort"
 	"math/rand"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/TheAlgorithms/Go/sort"
 )
 
 func testFramework(t *testing.T, sortingFunction func([]int) []int) {
@@ -83,6 +84,10 @@ func TestBubble(t *testing.T) {
 
 func TestBucketSort(t *testing.T) {
 	testFramework(t, sort.Bucket[int])
+}
+
+func TestCocktailSort(t *testing.T) {
+	testFramework(t, sort.Cocktail[int])
 }
 
 func TestExchange(t *testing.T) {


### PR DESCRIPTION
The cocktail sort (also known as cocktail shaker sort, bidirectional bubble sort, shaker sort, ripple sort, shuffle sort, or shuttle sort) is a variant of the bubble sort algorithm. It extends the bubble sort by operating in both directions (from array's beginning to its end, and from array's end to its beginning).

I based the implementation on the [Wikipedia page about Cocktail Sort](https://en.wikipedia.org/wiki/Cocktail_shaker_sort).

Also added this sort on the `sort_tests.go`