### PR TITLE
feat: reactivate `horspool`

### DIFF
--- a/strings/horspool/horspool.go
+++ b/strings/horspool/horspool.go
@@ -1,95 +1,39 @@
+// Implementation of the
+// [Boyer–Moore–Horspool algorithm](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore%E2%80%93Horspool_algorithm)
+
 package horspool
 
-// User defined.
-// Set to true to read input from two command line arguments
-// Set to false to read input from two files "pattern.txt" and "text.txt"
-// const commandLineInput bool = false
+import "errors"
 
-// Implementation of Boyer-Moore-Horspool algorithm (Suffix based approach).
-// Requires either a two command line arguments separated by a single space,
-// or two files in the same folder: "pattern.txt" containing the string to
-// be searched for, "text.txt" containing the text to be searched in.
-// func main() {
-// 	if commandLineInput == true { // case of command line input
-// 		args := os.Args
-// 		if len(args) <= 2 {
-// 			log.Fatal("Not enough arguments. Two string arguments separated by spaces are required!")
-// 		}
-// 		pattern := args[1]
-// 		s := args[2]
-// 		for i := 3; i < len(args); i++ {
-// 			s = s + " " + args[i]
-// 		}
-// 		if len(args[1]) > len(s) {
-// 			log.Fatal("Pattern  is longer than text!")
-// 		}
-// 		fmt.Printf("\nRunning: Horspool algorithm.\n\n")
-// 		fmt.Printf("Search word (%d chars long): %q.\n", len(args[1]), pattern)
-// 		fmt.Printf("Text        (%d chars long): %q.\n\n", len(s), s)
-// 		horspool(s, pattern)
-// 	} else if commandLineInput == false { // case of file line input
-// 		patFile, err := ioutil.ReadFile("pattern.txt")
-// 		if err != nil {
-// 			log.Fatal(err)
-// 		}
-// 		textFile, err := ioutil.ReadFile("text.txt")
-// 		if err != nil {
-// 			log.Fatal(err)
-// 		}
-// 		if len(patFile) > len(textFile) {
-// 			log.Fatal("Pattern  is longer than text!")
-// 		}
-// 		fmt.Printf("\nRunning: Horspool algorithm.\n\n")
-// 		fmt.Printf("Search word (%d chars long): %q.\n", len(patFile), patFile)
-// 		fmt.Printf("Text        (%d chars long): %q.\n\n", len(textFile), textFile)
-// 		horspool(string(textFile), string(patFile))
-// 	}
-// }
+var ErrNotFound = errors.New("pattern was not found in the input string")
 
-// // Function horspool performing the Horspool algorithm.
-// // Prints whether the word/pattern was found and on what position in the text or not.
-// func horspool(t, p string) {
-// 	m, n, c, pos := len(p), len(t), 0, 0
-// 	//Perprocessing
-// 	d := preprocess(t, p)
-// 	//Map output
-// 	fmt.Printf("Precomputed shifts per symbol: ")
-// 	for key, value := range d {
-// 		fmt.Printf("%c:%d; ", key, value)
-// 	}
-// 	fmt.Println()
-// 	//Searching
-// 	for pos <= n-m {
-// 		j := m
-// 		if t[pos+j-1] != p[j-1] {
-// 			fmt.Printf("\n   comparing characters %c %c at positions %d %d", t[pos+j-1], p[j-1], pos+j-1, j-1)
-// 			c++
-// 		}
-// 		for j > 0 && t[pos+j-1] == p[j-1] {
-// 			fmt.Printf("\n   comparing characters %c %c at positions %d %d", t[pos+j-1], p[j-1], pos+j-1, j-1)
-// 			c++
-// 			fmt.Printf(" - match")
-// 			j--
-// 		}
-// 		if j == 0 {
-// 			fmt.Printf("\n\nWord %q was found at position %d in %q. \n%d comparisons were done.", p, pos, t, c)
-// 			return
-// 		}
-// 		pos = pos + d[t[pos+m]]
-// 	}
-// 	fmt.Printf("\n\nWord was not found.\n%d comparisons were done.", c)
-// 	return
-// }
+func Horspool(t, p string) (int, error) {
+	pos := 0
+	shiftMap := computeShiftMap(t, p)
+	for pos <= len(t)-len(p) {
+		j := len(p)
+		for j > 0 && t[pos+j-1] == p[j-1] {
+			j--
+		}
+		if j == 0 {
+			return pos, nil
+		}
+		if pos+len(p) >= len(t) {
+			break
+		}
+		pos = pos + shiftMap[t[pos+len(p)]]
+	}
 
-// // Function that pre-computes map with Key: uint8 (char) Value: int.
-// // Values determine safe shifting of search window.
-// func preprocess(t, p string) (d map[uint8]int) {
-// 	d = make(map[uint8]int)
-// 	for i := 0; i < len(t); i++ {
-// 		d[t[i]] = len(p)
-// 	}
-// 	for i := 0; i < len(p); i++ {
-// 		d[p[i]] = len(p) - i
-// 	}
-// 	return d
-// }
+	return -1, ErrNotFound
+}
+
+func computeShiftMap(t, p string) (res map[uint8]int) {
+	res = make(map[uint8]int)
+	for i := 0; i < len(t); i++ {
+		res[t[i]] = len(p)
+	}
+	for i := 0; i < len(p); i++ {
+		res[p[i]] = len(p) - i
+	}
+	return res
+}

--- a/strings/horspool/horspool.go
+++ b/strings/horspool/horspool.go
@@ -8,32 +8,53 @@ import "errors"
 var ErrNotFound = errors.New("pattern was not found in the input string")
 
 func Horspool(t, p string) (int, error) {
-	pos := 0
+	// in order to handle multy-byte character properly
+	// the input is converted into rune arrays
+	return horspool([]rune(t), []rune(p))
+}
+
+func horspool(t, p []rune) (int, error) {
 	shiftMap := computeShiftMap(t, p)
+	pos := 0
 	for pos <= len(t)-len(p) {
-		j := len(p)
-		for j > 0 && t[pos+j-1] == p[j-1] {
-			j--
-		}
-		if j == 0 {
+		if isMatch(pos, t, p) {
 			return pos, nil
 		}
 		if pos+len(p) >= len(t) {
+			// because the remaining length of the input string
+			// is the same as the length of the pattern
+			// and it does mot match the pattern
+			// it is impossible to find the pattern
 			break
 		}
-		pos = pos + shiftMap[t[pos+len(p)]]
+
+		// because of the check above
+		// t[pos+len(p)] is defined
+		pos += shiftMap[t[pos+len(p)]]
 	}
 
 	return -1, ErrNotFound
 }
 
-func computeShiftMap(t, p string) (res map[uint8]int) {
-	res = make(map[uint8]int)
-	for i := 0; i < len(t); i++ {
-		res[t[i]] = len(p)
+// Checks if the array p matches the subarray of t starting at pos.
+// Note that backward iteration.
+// There are [other](https://en.wikipedia.org/wiki/Boyer%E2%80%93Moore%E2%80%93Horspool_algorithm#Tuning_the_comparison_loop)
+// approaches possible.
+func isMatch(pos int, t, p []rune) bool {
+	j := len(p)
+	for j > 0 && t[pos+j-1] == p[j-1] {
+		j--
 	}
-	for i := 0; i < len(p); i++ {
-		res[p[i]] = len(p) - i
+	return j == 0
+}
+
+func computeShiftMap(t, p []rune) (res map[rune]int) {
+	res = make(map[rune]int)
+	for _, tCode := range t {
+		res[tCode] = len(p)
+	}
+	for i, pCode := range p {
+		res[pCode] = len(p) - i
 	}
 	return res
 }

--- a/strings/horspool/horspool.go
+++ b/strings/horspool/horspool.go
@@ -23,7 +23,7 @@ func horspool(t, p []rune) (int, error) {
 		if pos+len(p) >= len(t) {
 			// because the remaining length of the input string
 			// is the same as the length of the pattern
-			// and it does mot match the pattern
+			// and it does not match the pattern
 			// it is impossible to find the pattern
 			break
 		}

--- a/strings/horspool/horspool_test.go
+++ b/strings/horspool/horspool_test.go
@@ -18,6 +18,8 @@ func TestLHorspool(t *testing.T) {
 		{"Xaaab", "X", 0},
 		{"XYaab", "XY", 0},
 		{"abcefghXYZ", "XYZ", 7},
+		{"abcefgh€YZ⌘", "€YZ", 7},
+		{"⌘bcefgh€YZ⌘", "€YZ", 7},
 		{"abc", "abc", 0},
 		{"", "", 0},
 		{"a", "", 0},
@@ -49,6 +51,8 @@ func TestLHorspoolNotExisintPattern(t *testing.T) {
 		{"aaaaaaaXaXaaaa", "XXX"},
 		{"aaaaaaaXaX", "XXX"},
 		{"XaX", "XXX"},
+		{"XaX", "XXX"},
+		{"\xe2\x8c\x98", "\x98"},
 	}
 	for _, tc := range testCases {
 		t.Run(fmt.Sprint("test with ", tc.input, " ", tc.pattern), func(t *testing.T) {

--- a/strings/horspool/horspool_test.go
+++ b/strings/horspool/horspool_test.go
@@ -1,0 +1,64 @@
+// horspool_test.go
+// description: Tests for horspool
+// see horspool.go
+
+package horspool
+
+import "testing"
+import "fmt"
+
+func TestLHorspool(t *testing.T) {
+	testCases := []struct {
+		input    string
+		pattern  string
+		expected int
+	}{
+		{"aaaaXaaa", "X", 4},
+		{"aaaaXXaa", "XX", 4},
+		{"Xaaab", "X", 0},
+		{"XYaab", "XY", 0},
+		{"abcefghXYZ", "XYZ", 7},
+		{"abc", "abc", 0},
+		{"", "", 0},
+		{"a", "", 0},
+		{"a", "a", 0},
+		{"aa", "a", 0},
+		{"aa", "aa", 0},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint("test with ", tc.input, " ", tc.pattern), func(t *testing.T) {
+			result, curError := Horspool(tc.input, tc.pattern)
+			if curError != nil {
+				t.Fatalf("Got unexpected error")
+			}
+			if tc.expected != result {
+				t.Fatalf("expected %d, got %d", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestLHorspoolNotExisintPattern(t *testing.T) {
+	testCases := []struct {
+		input   string
+		pattern string
+	}{
+		{"", "X"},
+		{"X", "Y"},
+		{"X", "XX"},
+		{"aaaaaaaXaXaaaa", "XXX"},
+		{"aaaaaaaXaX", "XXX"},
+		{"XaX", "XXX"},
+	}
+	for _, tc := range testCases {
+		t.Run(fmt.Sprint("test with ", tc.input, " ", tc.pattern), func(t *testing.T) {
+			result, curError := Horspool(tc.input, tc.pattern)
+			if curError != ErrNotFound {
+				t.Fatalf("Got unexpected error")
+			}
+			if result != -1 {
+				t.Fatalf("expected -1, got %d", result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Contributors guide: https://github.com/TheAlgorithms/Go/CONTRIBUTING.md
-->
There is some commented out code in [`horspool.go`](https://github.com/TheAlgorithms/Go/blob/58bb31e80f8347c91db049a09d32a4989c06b485/strings/horspool/horspool.go).
This PR _reactivates_ it by making all necessary changes.

When the given pattern is not present in the input string, I used a similar approach to the one in [./search](https://github.com/TheAlgorithms/Go/tree/master/search).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Added description of change
- [x] Added tests and example, test must pass
- [x] PR title follows semantic [commit guidelines](https://github.com/TheAlgorithms/Go/blob/master/CONTRIBUTING.md#Commit-Guidelines)
- [x] Search previous suggestions before making a new one, as yours may be a duplicate.
- [x] I acknowledge that all my contributions will be made under the project's license.

Notes: <!-- Please add a one-line description for developers or pull request viewers -->
_Reactivates_ [`horspool.go`](https://github.com/TheAlgorithms/Go/blob/58bb31e80f8347c91db049a09d32a4989c06b485/strings/horspool/horspool.go).