### PR TITLE
style: use proper spelling

### DIFF
--- a/strings/genetic/genetic.go
+++ b/strings/genetic/genetic.go
@@ -28,7 +28,7 @@ type PopulationItem struct {
 	Value float64
 }
 
-// Conf stands for cofigurations set provided to GeneticString function.
+// Conf stands for configurations set provided to GeneticString function.
 type Conf struct {
 	// Maximum size of the population.
 	// Bigger could be faster but more memory expensive.


### PR DESCRIPTION
There is a typo in:
https://github.com/TheAlgorithms/Go/blob/30392a3da977d3c3ebb94156489f3bd28d72c89d/strings/genetic/genetic.go#L31

causing some of the CI check [failing](https://github.com/TheAlgorithms/Go/actions/runs/6390761541/job/17344668371?pr=663).