### PR TITLE
fix. Update generics in counting sort

### DIFF
--- a/sort/countingsort.go
+++ b/sort/countingsort.go
@@ -8,16 +8,27 @@ package sort
 
 import "github.com/TheAlgorithms/Go/constraints"
 
-func Count[T constraints.Number](data []int) []int {
-	var aMin, aMax = -1000, 1000
+func Count[T constraints.Integer](data []T) []T {
+	if len(data) == 0 {
+		return data
+	}
+	var aMin, aMax = data[0], data[0]
+	for _, x := range data {
+		if x < aMin {
+			aMin = x
+		}
+		if x > aMax {
+			aMax = x
+		}
+	}
 	count := make([]int, aMax-aMin+1)
 	for _, x := range data {
-		count[x-aMin]++ // this is the reason for having only Number constraint instead of Ordered.
+		count[x-aMin]++ // this is the reason for having only Integer constraint instead of Ordered.
 	}
 	z := 0
 	for i, c := range count {
 		for c > 0 {
-			data[z] = i + aMin
+			data[z] = T(i) + aMin
 			z++
 			c--
 		}


### PR DESCRIPTION
Counting sort is usually applied to arrays of integers.