### PR TITLE
feat: add recursive fibonacci

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ Read our [Contribution Guidelines](CONTRIBUTING.md) before you contribute.
 
 1. [`Formula`](./math/fibonacci/fibonacci.go#L42):  Formula This function calculates the n-th fibonacci number using the [formula](https://en.wikipedia.org/wiki/Fibonacci_number#Relation_to_the_golden_ratio) Attention! Tests for large values fall due to rounding error of floating point numbers, works well, only on small numbers
 2. [`Matrix`](./math/fibonacci/fibonacci.go#L15):  Matrix This function calculates the n-th fibonacci number using the matrix method. [See](https://en.wikipedia.org/wiki/Fibonacci_number#Matrix_form)
+3. [`Recursive`](./math/fibonacci/fibonacci.go#L51):  Recursive calculates the n-th fibonacci number recursively by adding the previous two numbers. [See](https://en.wikipedia.org/wiki/Fibonacci_sequence#Definition)
 
 ---
 </details><details>

--- a/math/fibonacci/fibonacci.go
+++ b/math/fibonacci/fibonacci.go
@@ -45,3 +45,13 @@ func Formula(n uint) uint {
 	powPhi := math.Pow(phi, float64(n))
 	return uint(powPhi/sqrt5 + 0.5)
 }
+
+// Recursive calculates the n-th fibonacci number recursively by adding the previous two Fibonacci numbers.
+// This algorithm is extremely slow for bigger numbers, but provides a simpler implementation.
+func Recursive(n uint) uint {
+	if n <= 1 {
+		return n
+	}
+
+	return Recursive(n-1) + Recursive(n-2)
+}

--- a/math/fibonacci/fibonacci_test.go
+++ b/math/fibonacci/fibonacci_test.go
@@ -64,6 +64,19 @@ func TestFormula(t *testing.T) {
 	}
 }
 
+func TestRecursive(t *testing.T) {
+	tests := getTests()
+	for _, test := range tests {
+		if test.n <= 10 {
+			t.Run(test.name, func(t *testing.T) {
+				if got := Recursive(test.n); got != test.want {
+					t.Errorf("Return value = %v, want %v", got, test.want)
+				}
+			})
+		}
+	}
+}
+
 func BenchmarkNthFibonacci(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		dynamic.NthFibonacci(90)


### PR DESCRIPTION
The calculation of the Fibonacci number is [defined recursively](https://en.wikipedia.org/wiki/Fibonacci_sequence#Definition), but so far there was no recursive implementation yet.

I added the tests, but only run it for numbers up to 10 and I ignored the benchmark purposely, as it would take ages to calculate the 90 Fibonacci number with this approach :)