### PR TITLE
fix: remove redundant init step for unionFind

### DIFF
--- a/graph/kruskal.go
+++ b/graph/kruskal.go
@@ -28,12 +28,6 @@ func KruskalMST(n int, edges []Edge) ([]Edge, int) {
 	// Create a new UnionFind data structure with 'n' nodes
 	u := NewUnionFind(n)
 
-	// Initialize each node in the UnionFind data structure
-	for i := 0; i < n; i++ {
-		u.parent[i] = i
-		u.size[i] = 1
-	}
-
 	// Sort the edges in non-decreasing order based on their weights
 	sort.SliceStable(edges, func(i, j int) bool {
 		return edges[i].Weight < edges[j].Weight


### PR DESCRIPTION
It seems that node initialization in kruskal algorithm, is redundant and it is already being done inside [NewUnionFind](https://github.com/TheAlgorithms/Go/blob/6d839027b6765b7cd14b00ffdd54678bd70dc63e/graph/unionfind.go#L27) function.

This PR aims to fix the twice initialization to get a more clean impl for kruskal algorithm