### PR TITLE
chore: update `actions/setup-go` to `v5`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.18'
       - name: Run Golang CI Lint

--- a/.github/workflows/godocmd.yml
+++ b/.github/workflows/godocmd.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: '^1.18'
       - name: Install GoDocMD

--- a/.github/workflows/upload_coverage_report.yml
+++ b/.github/workflows/upload_coverage_report.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.18'
       - name: Generate code coverage


### PR DESCRIPTION
This PR updates the `actions/setup-go` to `v5`. This helps to avoid the _Node.js 16_ warning.