### PR TITLE
[Reimplementation] Sieve of eratosthenes

### DIFF
--- a/math/prime/sieve2.go
+++ b/math/prime/sieve2.go
@@ -1,0 +1,21 @@
+/* sieve2.go - Sieve of Eratosthenes
+ * Algorithm to generate prime numbers up to a limit
+ * Author: ddaniel27
+ */
+package prime
+
+func SieveEratosthenes(limit int) []int {
+	primes := make([]int, 0)
+	sieve := make([]int, limit+1) // make a slice of size limit+1
+
+	for i := 2; i <= limit; i++ {
+		if sieve[i] == 0 { // if the number is not marked as composite
+			primes = append(primes, i)           // add it to the list of primes
+			for j := i * i; j <= limit; j += i { // mark all multiples of i as composite
+				sieve[j] = 1
+			}
+		}
+	}
+
+	return primes
+}

--- a/math/prime/sieve2_test.go
+++ b/math/prime/sieve2_test.go
@@ -1,0 +1,43 @@
+package prime_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/TheAlgorithms/Go/math/prime"
+)
+
+func TestSieveEratosthenes(t *testing.T) {
+	tests := []struct {
+		name  string
+		limit int
+		want  []int
+	}{
+		{
+			name:  "First 10 primes test",
+			limit: 30,
+			want:  []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29},
+		},
+		{
+			name:  "First 20 primes test",
+			limit: 71,
+			want:  []int{2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := prime.SieveEratosthenes(tt.limit)
+
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("SieveEratosthenes() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func BenchmarkSieveEratosthenes(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_ = prime.SieveEratosthenes(10)
+	}
+}


### PR DESCRIPTION
This is a reimplementation for the algorithm sieve of erathosthenes, this reimplementation doesn't use channels and has a better performance than the actual sieve in the repository.

Benchmarks for `limit=10000`

Current implementation:
```
goos: linux                                                                                                                                                                                                  
goarch: amd64
pkg: github.com/TheAlgorithms/Go/math/prime
cpu: AMD Ryzen 5 5600G with Radeon Graphics
BenchmarkSieve10-12            1        3019938961 ns/op         7515624 B/op      40073 allocs/op
PASS
ok      github.com/TheAlgorithms/Go/math/prime  3.206s
```

My implementation:
```
goos: linux                                                                                                                                                                                                  
goarch: amd64
pkg: github.com/TheAlgorithms/Go/math/prime
cpu: AMD Ryzen 5 5600G with Radeon Graphics
BenchmarkSieveEratosthenes-12              45400             27502 ns/op          107129 B/op         13 allocs/op
PASS
ok      github.com/TheAlgorithms/Go/math/prime  1.707s
```