### PR TITLE
Improved HashMap implementation

### DIFF
--- a/structure/hashmap/hashmap.go
+++ b/structure/hashmap/hashmap.go
@@ -20,16 +20,16 @@ type HashMap struct {
 	table    []*node
 }
 
-// New returns a new HashMap instance
-func New() *HashMap {
+// DefaultNew returns a new HashMap instance with default values
+func DefaultNew() *HashMap {
 	return &HashMap{
 		capacity: defaultCapacity,
 		table:    make([]*node, defaultCapacity),
 	}
 }
 
-// Make creates a new HashMap instance with the specified size and capacity
-func Make(size, capacity uint64) *HashMap {
+// New creates a new HashMap instance with the specified size and capacity
+func New(size, capacity uint64) *HashMap {
 	return &HashMap{
 		size:     size,
 		capacity: capacity,

--- a/structure/hashmap/hashmap_test.go
+++ b/structure/hashmap/hashmap_test.go
@@ -7,8 +7,7 @@ import (
 )
 
 func TestHashMap(t *testing.T) {
-
-	mp := hashmap.New()
+	mp := hashmap.DefaultNew()
 
 	t.Run("Test 1: Put(10) and checking if Get() is correct", func(t *testing.T) {
 		mp.Put("test", 10)
@@ -67,7 +66,7 @@ func TestHashMap(t *testing.T) {
 	})
 
 	t.Run("Test 8: Resizing a map", func(t *testing.T) {
-		mp := hashmap.Make(4, 4)
+		mp := hashmap.New(4, 4)
 
 		for i := 0; i < 20; i++ {
 			mp.Put(i, 40)


### PR DESCRIPTION
As I was going through the current implementation of HashMap in Go, I noticed that the following improvements could be made:

**Enhanced Collision Handling:**

- Modified the Put method to handle collisions using linked lists (chaining).
- Ensured that new key-value pairs are correctly inserted even when collisions occur.

**Resizing Logic**

- Refactored the resize method to correctly rehash and relocate all nodes.
- The hash map now doubles its capacity when the load factor exceeds 0.75, ensuring efficient operations.

**Refactored Node Retrieval:**

- Implemented getNodeByKey to traverse the linked list at a given hash index to find the node with the matching key.
- Updated the Get method to use getNodeByKey for retrieving values.

**Code Cleanup:**

- Removed redundant functions (newNode and newNodeWithNext).
- Added comments.

**Miscellaneous:**
- Corrected the Make function to return a pointer to the HashMap.
- Improved hashing function for better distribution of keys.

This PR ensures that the HashMap correctly handles collisions, dynamically resizes based on the load factor, and maintains efficient access and modification operations.