### PR TITLE
test(search): add duplicate-element tests for binary search

### DIFF
--- a/search/binary_test.go
+++ b/search/binary_test.go
@@ -53,6 +53,52 @@ func TestUpperBound(t *testing.T) {
 	}
 }
 
+func TestBinaryWithDuplicates(t *testing.T) {
+	arr := []int{1, 2, 4, 4, 4, 6, 7, 8}
+	target := 4
+
+	result, err := Binary(arr, target, 0, len(arr)-1)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result < 0 || result >= len(arr) {
+		t.Fatalf("returned invalid index: %d", result)
+	}
+
+	if arr[result] != target {
+		t.Fatalf(
+			"expected target %d at returned index, got %d",
+			target,
+			arr[result],
+		)
+	}
+}
+
+func TestBinaryIterativeWithDuplicates(t *testing.T) {
+	arr := []int{1, 2, 4, 4, 4, 6, 7, 8}
+	target := 4
+
+	result, err := BinaryIterative(arr, target)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result < 0 || result >= len(arr) {
+		t.Fatalf("returned invalid index: %d", result)
+	}
+
+	if arr[result] != target {
+		t.Fatalf(
+			"expected target %d at returned index, got %d",
+			target,
+			arr[result],
+		)
+	}
+}
+
 func BenchmarkBinary(b *testing.B) {
 	testCase := generateBenchmarkTestCase()
 	b.ResetTimer() // this is important because the generateBenchmarkTestCase() is expensive


### PR DESCRIPTION
## Summary

Added duplicate-element test coverage for binary search implementations.

Some search algorithms may return the first occurrence of a target, while others may return any valid matching index when duplicate values exist. These tests validate correctness by checking the returned value rather than enforcing a specific duplicate index.

## Changes

* Added duplicate-element tests for:

  * Binary
  * BinaryIterative
* Validated returned indices safely against target values
* Preserved current implementation semantics